### PR TITLE
Update packages for removing the `SWXMLHash` package

### DIFF
--- a/Package.pins
+++ b/Package.pins
@@ -38,12 +38,6 @@
       "version": "3.2.1"
     },
     {
-      "package": "SWXMLHash",
-      "reason": null,
-      "repositoryURL": "git@github.com:drmohundro/SWXMLHash.git",
-      "version": "3.0.4"
-    },
-    {
       "package": "Spectre",
       "reason": null,
       "repositoryURL": "https://github.com/kylef/Spectre.git",


### PR DESCRIPTION
Just executed `swift package update` for removing the `SWXMLHash` package.