### PR TITLE
excluding /usr/local/bin in an archive

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -41,7 +41,7 @@ curl -i -X PUT $formula_url \
 }"
 
 brew upgrade $lib_name
-zip $lib_name.zip /usr/local/bin/$lib_name
+zip -j $lib_name.zip /usr/local/bin/$lib_name
 
 github-release release \
     --user mono0926 \


### PR DESCRIPTION
I ran the installation as follows failed to copy the file.

```bash
$ curl -fsSL https://raw.githubusercontent.com/mono0926/LicensePlist/master/install.sh | sh

Archive:  license-plist.zip                       
  inflating: usr/local/bin/license-plist          
cp: license-plist: No such file or directory  
```

It seems a problem with the directory structure in license-plist.zip.

```bash
$ unzip -l license-plist.zip
Archive:  license-plist.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
  9704096  05-25-2017 22:10   usr/local/bin/license-plist
---------                     -------
  9704096                     1 file
```