### PR TITLE
Revert "Cut `mkdir`"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ xcode:
 	swift package generate-xcodeproj
 
 install: build
+	mkdir -p "$(PREFIX)/bin"
 	cp -f ".build/release/LicensePlist" "$(PREFIX)/bin/license-plist"
 
 portable_zip: build


### PR DESCRIPTION
Fix https://github.com/mono0926/LicensePlist/issues/72

This reverts commit 2e3abcc605107d89d5b0a2da77e71a9df8018877.