### PR TITLE
Added capablility to supply manual license information

### DIFF
--- a/Sources/LicensePlistCore/Entity/Manual.swift
+++ b/Sources/LicensePlistCore/Entity/Manual.swift
@@ -1,0 +1,68 @@
+import Foundation
+import APIKit
+import LoggerAPI
+import Yaml
+
+public class Manual: Library {
+    public let name: String
+    public var body: String?    // Used as a container between YAML and ManualLicence
+    public var source: String?
+    public var nameSpecified: String?
+    public var version: String?
+
+    init(name n: String, source: String?, nameSpecified: String?, version: String?) {
+        self.name = n
+        self.source = source
+        self.nameSpecified = nameSpecified
+        self.version = version
+    }
+}
+
+extension Manual {
+    public static func==(lhs: Manual, rhs: Manual) -> Bool {
+        return lhs.name == rhs.name &&
+            lhs.nameSpecified == rhs.nameSpecified &&
+            lhs.version == rhs.version
+    }
+}
+
+extension Manual: CustomStringConvertible {
+    public var description: String {
+        return "name: \(name), source: \(source ?? ""), nameSpecified: \(nameSpecified ?? ""), version: \(version ?? "")"
+    }
+}
+
+extension Manual {
+    public static func load(_ raw: [Yaml],
+                            renames: [String: String]) -> [Manual] {
+        return raw.map { (manualEntry) -> Manual in
+            var name = ""
+            var body = ""
+            var source = ""
+            var rename = ""
+            var version = ""
+            for valuePair in manualEntry.dictionary ?? [:] {
+                switch valuePair.key.string ?? "" {
+                case "source":
+                    source = valuePair.value.string ?? ""
+                    break
+                case "name":
+                    name = valuePair.value.string ?? ""
+                    break
+                case "version":
+                    version = valuePair.value.string ?? ""
+                    break
+                case "body":
+                    body = valuePair.value.string ?? ""
+                    break
+                default:
+                    Log.warning("Tried to parse an unknown YAML key")
+                }
+            }
+            rename = renames[name] ?? ""
+            let manual = Manual(name: name, source: source, nameSpecified: rename, version: version)
+            manual.body = body  // This is so that we do not have to store a body at all ( for testing purposes mostly )
+            return manual
+        }
+    }
+}

--- a/Sources/LicensePlistCore/Entity/ManualLicense.swift
+++ b/Sources/LicensePlistCore/Entity/ManualLicense.swift
@@ -1,0 +1,25 @@
+import Foundation
+import LoggerAPI
+
+public struct ManualLicense: License, Equatable {
+    public let library: Manual
+    public let body: String
+
+    public static func==(lhs: ManualLicense, rhs: ManualLicense) -> Bool {
+        return lhs.library == rhs.library
+    }
+}
+
+extension ManualLicense: CustomStringConvertible {
+    public var description: String {
+        return "name: \(library.name), nameSpecified: \(library.nameSpecified ?? ""), version: \(library.version ?? "")\nbody: \(String(body.characters.prefix(20)))…"
+    }
+}
+
+extension ManualLicense {
+    public static func load(_ manuals: [Manual]) -> [ManualLicense] {
+        return manuals.map {
+            return ManualLicense(library: $0, body: $0.body ?? "")
+        }
+    }
+}

--- a/Sources/LicensePlistCore/LicensePlist.swift
+++ b/Sources/LicensePlistCore/LicensePlist.swift
@@ -11,6 +11,7 @@ public final class LicensePlist {
         var info = PlistInfo(options: options)
         info.loadCocoaPodsLicense(acknowledgements: readPodsAcknowledgements(path: options.podsPath))
         info.loadGitHubLibraries(cartfile: readCartfile(path: options.cartfilePath))
+        info.loadManualLibraries()
         info.compareWithLatestSummary()
         info.downloadGitHubLicenses()
         info.collectLicenseInfos()

--- a/Tests/LicensePlistTests/Entity/CocoaPodsTests.swift
+++ b/Tests/LicensePlistTests/Entity/CocoaPodsTests.swift
@@ -14,7 +14,7 @@ class CocoaPodsTests: XCTestCase {
         let content = try! String(contentsOf: URL(string: path)!)
         let results = CocoaPodsLicense.load(content,
                                             versionInfo: VersionInfo(dictionary: ["Firebase": "1.2.3"]),
-                                            config: Config(githubs: [], excludes: [], renames: ["Firebase": "Firebase2"]))
+                                            config: Config(githubs: [], manuals: [], excludes: [], renames: ["Firebase": "Firebase2"]))
         XCTAssertFalse(results.isEmpty)
         XCTAssertEqual(results.count, 11)
         let licenseFirst = results.first!

--- a/Tests/LicensePlistTests/Entity/ConfigTests.swift
+++ b/Tests/LicensePlistTests/Entity/ConfigTests.swift
@@ -5,19 +5,20 @@ import XCTest
 class ConfigTests: XCTestCase {
 
     func testInit_empty_yaml() {
-        XCTAssertEqual(Config(yaml: ""), Config(githubs: [], excludes: [], renames: [:]))
+        XCTAssertEqual(Config(yaml: ""), Config(githubs: [], manuals: [], excludes: [], renames: [:]))
     }
     func testInit_sample() {
         let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Tests/LicensePlistTests/Resources/license_plist.yml"
         XCTAssertEqual(Config(yaml: URL(string: path)!.lp.download().resultSync().value!),
                        Config(githubs: [GitHub(name: "LicensePlist", nameSpecified: "License Plist", owner: "mono0926", version: "1.2.0"),
                                         GitHub(name: "NativePopup", nameSpecified: nil, owner: "mono0926", version: nil)],
+                              manuals: [Manual(name: "WebRTC", source: "https://webrtc.googlesource.com/src", nameSpecified: "Web RTC", version: "M61")],
                               excludes: ["RxSwift", "ios-license-generator", "/^Core.*$/"],
-                              renames: ["LicensePlist": "License Plist"]))
+                              renames: ["LicensePlist": "License Plist", "WebRTC": "Web RTC"]))
     }
 
     func testExcluded() {
-        let target = Config(githubs: [], excludes: ["lib1"], renames: [:])
+        let target = Config(githubs: [], manuals: [], excludes: ["lib1"], renames: [:])
         XCTAssertTrue(target.excluded(name: "lib1"))
         XCTAssertFalse(target.excluded(name: "lib2"))
     }
@@ -28,22 +29,22 @@ class ConfigTests: XCTestCase {
     }
 
     func testExcluded_regex() {
-        let target = Config(githubs: [], excludes: ["/^lib.*$/"], renames: [:])
+        let target = Config(githubs: [], manuals: [], excludes: ["/^lib.*$/"], renames: [:])
         XCTAssertTrue(target.excluded(name: "lib1"))
         XCTAssertTrue(target.excluded(name: "lib2"))
         XCTAssertFalse(target.excluded(name: "hello"))
     }
 
     func testApply_filterExcluded() {
-        let config = Config(githubs: [], excludes: ["lib2"], renames: [:])
+        let config = Config(githubs: [], manuals: [], excludes: ["lib2"], renames: [:])
         let shouldBeIncluded = GitHub(name: "lib1", nameSpecified: nil, owner: "o1", version: nil)
         let result = config.filterExcluded([shouldBeIncluded, GitHub(name: "lib2", nameSpecified: nil, owner: "o2", version: nil)])
         XCTAssertEqual(result, [shouldBeIncluded])
     }
 
     func testApply_githubs() {
-        let github1 = GitHub(name: "github1", nameSpecified: nil, owner: "g1", version: nil)
-        let config = Config(githubs: [github1], excludes: ["lib2"], renames: [:])
+        let github1 = GitHub(name: "github1",  nameSpecified: nil, owner: "g1", version: nil)
+        let config = Config(githubs: [github1], manuals: [], excludes: ["lib2"], renames: [:])
         let shouldBeIncluded = GitHub(name: "lib1", nameSpecified: nil, owner: "o1", version: nil)
         let result = config.apply(githubs: [shouldBeIncluded, GitHub(name: "lib2", nameSpecified: nil, owner: "o2", version: nil)])
         XCTAssertEqual(result, [github1, shouldBeIncluded])

--- a/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
+++ b/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
@@ -21,6 +21,7 @@ class PlistInfoTests: XCTestCase {
                                                                   nameSpecified: nil,
                                                                   owner: "owner",
                                                                   version: nil)],
+                                                 manuals: [],
                                                  excludes: ["exclude"],
                                                  renames: ["Himotoki": "Himotoki2"]))
 
@@ -69,6 +70,7 @@ class PlistInfoTests: XCTestCase {
     func testCompareWithLatestSummary() {
         var target = PlistInfo(options: options)
         target.cocoaPodsLicenses = []
+        target.manualLicenses = []
         target.githubLibraries = []
 
         XCTAssertNil(target.summary)
@@ -106,13 +108,17 @@ class PlistInfoTests: XCTestCase {
                                                                           kind: LicenseKindResponse(name: "name",
                                                                                                     spdxId: nil)))
         target.cocoaPodsLicenses = []
+        let manual = Manual(name: "FooBar", source: "https://foo.bar", nameSpecified: nil, version: nil)
+        let manualLicense = ManualLicense(library: manual,
+                                          body: "body")
+        target.manualLicenses = [manualLicense]
         target.githubLicenses = [githubLicense]
 
         XCTAssertNil(target.licenses)
         target.collectLicenseInfos()
         let licenses = target.licenses!
-        XCTAssertEqual(licenses.count, 1)
-        let license = licenses.first!
+        XCTAssertEqual(licenses.count, 2)
+        let license = licenses.last!
         XCTAssertEqual(license.name, "LicensePlist")
     }
 
@@ -160,6 +166,8 @@ class PlistInfoTests: XCTestCase {
         target.githubLicenses = [githubLicense]
         let podsLicense = CocoaPodsLicense(library: CocoaPods(name: "", nameSpecified: nil, version: nil), body: "body")
         target.cocoaPodsLicenses = [podsLicense]
+        let manualLicense = ManualLicense(library: Manual(name: "", source: nil, nameSpecified: nil, version: nil), body: "body")
+        target.manualLicenses = [manualLicense]
         target.licenses = [githubLicense, podsLicense]
         target.summary = ""
         target.summaryPath = URL(fileURLWithPath: "")

--- a/Tests/LicensePlistTests/Resources/license_plist.yml
+++ b/Tests/LicensePlistTests/Resources/license_plist.yml
@@ -8,6 +8,38 @@ github:
   # Depricated(Will be removed at Version 2. Use above.)
   - mono0926/NativePopup
 
+# Specify libraries manually
+manual:
+  - source: https://webrtc.googlesource.com/src
+    name: WebRTC
+    version: M61
+    body: '
+    Copyright (c) 2011, The WebRTC project authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+  * Neither the name of Google nor the names of its contributors may
+    be used to endorse or promote products derived from this software
+    without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+'
+
 # Specify libraries to be excluded.
 exclude:
   - RxSwift
@@ -17,3 +49,4 @@ exclude:
 # Specify libraries' names to be renamed.
 rename:
   LicensePlist: License Plist # Rename LicensePlist to "License Plist"
+  WebRTC: Web RTC # Rename WebRTC to "Web RTC" (which is faulty, but used for test)


### PR DESCRIPTION
In response to #23, i have made it possible to add manual licence information in the config yaml file.

One test will not pass since all tests require the test-files to be updated on the remote (which is this repo).