### PR TITLE
Wrong title if no rename

### DIFF
--- a/Sources/LicensePlistCore/Entity/Manual.swift
+++ b/Sources/LicensePlistCore/Entity/Manual.swift
@@ -22,7 +22,8 @@ extension Manual {
     public static func==(lhs: Manual, rhs: Manual) -> Bool {
         return lhs.name == rhs.name &&
             lhs.nameSpecified == rhs.nameSpecified &&
-            lhs.version == rhs.version
+            lhs.version == rhs.version &&
+        lhs.source == rhs.source
     }
 }
 
@@ -37,26 +38,24 @@ extension Manual {
                             renames: [String: String]) -> [Manual] {
         return raw.map { (manualEntry) -> Manual in
             var name = ""
-            var body = ""
-            var source = ""
-            var rename = ""
-            var version = ""
+            var body: String?
+            var source: String?
+            var version: String?
             for valuePair in manualEntry.dictionary ?? [:] {
                 switch valuePair.key.string ?? "" {
                 case "source":
-                    source = valuePair.value.string ?? ""
+                    source = valuePair.value.string
                 case "name":
                     name = valuePair.value.string ?? ""
                 case "version":
-                    version = valuePair.value.string ?? ""
+                    version = valuePair.value.string
                 case "body":
-                    body = valuePair.value.string ?? ""
+                    body = valuePair.value.string
                 default:
                     Log.warning("Tried to parse an unknown YAML key")
                 }
             }
-            rename = renames[name] ?? ""
-            let manual = Manual(name: name, source: source, nameSpecified: rename, version: version)
+            let manual = Manual(name: name, source: source, nameSpecified: renames[name], version: version)
             manual.body = body  // This is so that we do not have to store a body at all ( for testing purposes mostly )
             return manual
         }

--- a/Sources/LicensePlistCore/Entity/ManualLicense.swift
+++ b/Sources/LicensePlistCore/Entity/ManualLicense.swift
@@ -6,7 +6,8 @@ public struct ManualLicense: License, Equatable {
     public let body: String
 
     public static func==(lhs: ManualLicense, rhs: ManualLicense) -> Bool {
-        return lhs.library == rhs.library
+        return lhs.library == rhs.library &&
+        lhs.body == rhs.body
     }
 }
 


### PR DESCRIPTION
So it seems i made a booboo... I did not understand the API to its fullest and thus this little (but serious) error sneaked in. 

Fixes:
* Fixes an issue where manual entries would not get their titles correct (would be empty strings) in the cases where no renames would be given. This commit also fixes some issues where updated license information would not update if changed.