### PR TITLE
Limit request number to avoid mass request

### DIFF
--- a/Sources/LicensePlistCore/Entity/PlistInfo.swift
+++ b/Sources/LicensePlistCore/Entity/PlistInfo.swift
@@ -63,6 +63,7 @@ struct PlistInfo {
         guard let githubLibraries = githubLibraries else { preconditionFailure() }
 
         let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 10
         let carthageOperations = githubLibraries.map { GitHubLicense.download($0) }
         queue.addOperations(carthageOperations, waitUntilFinished: true)
         githubLicenses = carthageOperations.map { $0.result?.value }.flatMap { $0 }


### PR DESCRIPTION
# Problem
LicensePlist stuck if number of library comes to 64 (Reproducible with Cartfile attached)

# Fix
Limit the concurrent network request to a small count.(not sure 10 is a good value though)

# Files
[Cartfile.txt](https://github.com/mono0926/LicensePlist/files/2256528/Cartfile.txt)
