### PR TITLE
Add ability to specify license files in the manual section

### DIFF
--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -5,7 +5,7 @@ import LoggerAPI
 
 private func loadConfig(configPath: URL) -> Config {
     if let yaml = configPath.lp.read() {
-        return Config(yaml: yaml)
+        return Config(yaml: yaml, configBasePath: configPath.deletingLastPathComponent())
     }
     return Config.empty
 }

--- a/Sources/LicensePlistCore/Entity/Config.swift
+++ b/Sources/LicensePlistCore/Entity/Config.swift
@@ -13,7 +13,7 @@ public struct Config {
 
     public static let empty = Config(githubs: [], manuals: [], excludes: [], renames: [:])
 
-    public init(yaml: String) {
+    public init(yaml: String, configBasePath: URL) {
         let value = try! Yaml.load(yaml)
         let excludes = value["exclude"].array?.map { $0.string! } ?? []
         let renames = value["rename"].dictionary?.reduce([String: String]()) { sum, e in
@@ -23,7 +23,7 @@ public struct Config {
             return sum
             } ?? [:]
         let manuals = value["manual"].array ?? []
-        let manualList = Manual.load(manuals, renames: renames)
+        let manualList = Manual.load(manuals, renames: renames, configBasePath: configBasePath)
         let githubs = value["github"].array?.map { $0.string }.flatMap { $0 } ?? []
         let gitHubList = githubs.map { GitHub.load($0, renames: renames, mark: "", quotes: "") }.flatMap { $0 }
         gitHubList.forEach {

--- a/Sources/LicensePlistCore/Entity/Manual.swift
+++ b/Sources/LicensePlistCore/Entity/Manual.swift
@@ -35,7 +35,7 @@ extension Manual: CustomStringConvertible {
 
 extension Manual {
     public static func load(_ raw: [Yaml],
-                            renames: [String: String]) -> [Manual] {
+                            renames: [String: String], configBasePath: URL) -> [Manual] {
         return raw.map { (manualEntry) -> Manual in
             var name = ""
             var body: String?
@@ -51,6 +51,9 @@ extension Manual {
                     version = valuePair.value.string
                 case "body":
                     body = valuePair.value.string
+                case "file":
+                    let url = configBasePath.appendingPathComponent(valuePair.value.string!)
+                    body = try! String(contentsOf: url)
                 default:
                     Log.warning("Tried to parse an unknown YAML key")
                 }

--- a/Tests/LicensePlistTests/Entity/ConfigTests.swift
+++ b/Tests/LicensePlistTests/Entity/ConfigTests.swift
@@ -5,17 +5,18 @@ import XCTest
 class ConfigTests: XCTestCase {
 
     func testInit_empty_yaml() {
-        XCTAssertEqual(Config(yaml: ""), Config(githubs: [], manuals: [], excludes: [], renames: [:]))
+        XCTAssertEqual(Config(yaml: "", configBasePath: URL(fileURLWithPath: "")), Config(githubs: [], manuals: [], excludes: [], renames: [:]))
     }
     func testInit_sample() {
-        let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Tests/LicensePlistTests/Resources/license_plist.yml"
-        XCTAssertEqual(Config(yaml: URL(string: path)!.lp.download().resultSync().value!),
+        let url = URL(string: "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Tests/LicensePlistTests/Resources/license_plist.yml")!
+        XCTAssertEqual(Config(yaml: url.lp.download().resultSync().value!, configBasePath: url.deletingLastPathComponent()),
                        Config(githubs: [GitHub(name: "LicensePlist", nameSpecified: "License Plist", owner: "mono0926", version: "1.2.0"),
                                         GitHub(name: "NativePopup", nameSpecified: nil, owner: "mono0926", version: nil)],
                               manuals: [Manual(name: "WebRTC",
                                                source: "https://webrtc.googlesource.com/src",
                                                nameSpecified: "Web RTC",
-                                               version: "M61")],
+                                               version: "M61"),
+                                        Manual(name: "Dummy License File", source: nil, nameSpecified: nil, version: nil)],
                               excludes: ["RxSwift", "ios-license-generator", "/^Core.*$/"],
                               renames: ["LicensePlist": "License Plist", "WebRTC": "Web RTC"]))
     }

--- a/Tests/LicensePlistTests/Resources/dummy_license.txt
+++ b/Tests/LicensePlistTests/Resources/dummy_license.txt
@@ -1,0 +1,4 @@
+A LICENSE for Testing
+
+This text file is used for testing manual configuration.
+The file is specified with "file" key in the manual section.

--- a/Tests/LicensePlistTests/Resources/license_plist.yml
+++ b/Tests/LicensePlistTests/Resources/license_plist.yml
@@ -40,6 +40,10 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 '
 
+# Specify license files manually
+  - name: "Dummy License File"
+    file: "dummy_license.txt"
+
 # Specify libraries to be excluded.
 exclude:
   - RxSwift


### PR DESCRIPTION
By specifying relative path from the config file in the manual section, its content would be written as a license text to the plist file. We would not need to copy texts from libraries which are manually added.

```yaml
# minimum requirements
manual:
  - name: "Library"
    file: "path/to/license.txt"
```