### PR TITLE
Support for Markdown and HTML, also lets you change the prefix used.

### DIFF
--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -15,9 +15,12 @@ let main = command(Option("cartfile-path", default: Consts.cartfileName),
                    Option("output-path", default: Consts.outputPath),
                    Option("github-token", default: ""),
                    Option("config-path", default: Consts.configPath),
+                   Option("prefix", default: Consts.prefix),
+                   Option("html-path", default: ""),
+                   Option("markdown-path", default: ""),
                    Flag("force"),
                    Flag("add-version-numbers"),
-                   Flag("suppress-opening-directory")) { cartfile, podsPath, output, gitHubToken, configPath, force, version, suppressOpen in
+                   Flag("suppress-opening-directory")) { cartfile, podsPath, output, gitHubToken, configPath, prefix, htmlPath, markdownPath, force, version, suppressOpen in
 
                     Logger.configure()
                     var config = loadConfig(configPath: URL(fileURLWithPath: configPath))
@@ -27,7 +30,10 @@ let main = command(Option("cartfile-path", default: Consts.cartfileName),
                     let options = Options(outputPath: URL(fileURLWithPath: output),
                                           cartfilePath: URL(fileURLWithPath: cartfile),
                                           podsPath: URL(fileURLWithPath: podsPath),
+                                          prefix: prefix,
                                           gitHubToken: gitHubToken.isEmpty ? nil : gitHubToken,
+                                          htmlPath: htmlPath.isEmpty ? nil : URL(fileURLWithPath: htmlPath),
+                                          markdownPath: markdownPath.isEmpty ? nil : URL(fileURLWithPath: markdownPath),
                                           config: config)
                     let tool = LicensePlist()
                     tool.process(options: options)

--- a/Sources/LicensePlistCore/Entity/LicenseHTMLHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicenseHTMLHolder.swift
@@ -1,0 +1,43 @@
+import Foundation
+import LoggerAPI
+
+struct LicenseHTMLHolder {
+    let html: String
+    static func load(licenses: [LicenseInfo], options: Options) -> LicenseHTMLHolder {
+        var html = """
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>Acknowledgements</title>
+    </head>
+    <body>
+        <h1>Acknowledgements</h1>
+        <p>
+            This project makes use of the following third party libraries:
+        </p>
+
+"""
+        licenses.forEach { license in
+            html += """
+        <h2>\(license.name(withVersion: options.config.addVersionNumbers))</h2>
+        <pre>\(license.body)</pre>
+
+"""
+        }
+        html += """
+    </body>
+</html>
+"""
+        return LicenseHTMLHolder(html: html)
+    }
+
+    func write(to htmlPath: URL) {
+        do {
+            try html.data(using: .utf8)!.write(to: htmlPath)
+        } catch let e {
+            Log.error("Failed to write to (htmlPath: \(htmlPath)).\nerror: \(e)")
+        }
+
+    }
+}

--- a/Sources/LicensePlistCore/Entity/LicenseMarkdownHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicenseMarkdownHolder.swift
@@ -1,0 +1,22 @@
+import Foundation
+import LoggerAPI
+
+struct LicenseMarkdownHolder {
+    let markdown: String
+    static func load(licenses: [LicenseInfo], options: Options) -> LicenseMarkdownHolder {
+        var markdown = "# Acknowledgements\nThis project makes use of the following third party libraries:\n\n"
+        licenses.forEach { license in
+            markdown += "## \(license.name(withVersion: options.config.addVersionNumbers))\n\n\(license.body)\n\n"
+        }
+        return LicenseMarkdownHolder(markdown: markdown)
+    }
+
+    func write(to markdownPath: URL) {
+        do {
+            try markdown.data(using: .utf8)!.write(to: markdownPath)
+        } catch let e {
+            Log.error("Failed to write to (markdownPath: \(markdownPath)).\nerror: \(e)")
+        }
+
+    }
+}

--- a/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
@@ -4,11 +4,11 @@ import LoggerAPI
 struct LicensePlistHolder {
     let root: Data
     let items: [(LicenseInfo, Data)]
-    static func load(licenses: [LicenseInfo], config: Config) -> LicensePlistHolder {
+    static func load(licenses: [LicenseInfo], options: Options) -> LicensePlistHolder {
         let rootItems: [[String: String]] = licenses.map { license in
             return ["Type": "PSChildPaneSpecifier",
-                    "Title": license.name(withVersion: config.addVersionNumbers),
-                    "File": "\(Consts.prefix)/\(license.name)"]
+                    "Title": license.name(withVersion: options.config.addVersionNumbers),
+                    "File": "\(options.prefix)/\(license.name)"]
         }
         let root = try! PropertyListSerialization.data(fromPropertyList: ["PreferenceSpecifiers": rootItems],
                                                        format: .xml,

--- a/Sources/LicensePlistCore/Entity/Options.swift
+++ b/Sources/LicensePlistCore/Entity/Options.swift
@@ -4,17 +4,29 @@ public struct Options {
     public let outputPath: URL
     public let cartfilePath: URL
     public let podsPath: URL
+    public let prefix: String
     public let gitHubToken: String?
+    public let htmlPath: URL?
+    public let markdownPath: URL?
     public let config: Config
+
+    public static let empty = Options(outputPath: URL(fileURLWithPath: ""), cartfilePath: URL(fileURLWithPath: ""), podsPath: URL(fileURLWithPath: ""), prefix: "", gitHubToken: nil, htmlPath: nil, markdownPath: nil, config: Config.empty)
+
     public init(outputPath: URL,
                 cartfilePath: URL,
                 podsPath: URL,
+                prefix: String,
                 gitHubToken: String?,
+                htmlPath: URL?,
+                markdownPath: URL?,
                 config: Config) {
         self.outputPath = outputPath
         self.cartfilePath = cartfilePath
         self.podsPath = podsPath
+        self.prefix = prefix
         self.gitHubToken = gitHubToken
+        self.htmlPath = htmlPath
+        self.markdownPath = markdownPath
         self.config = config
     }
 }

--- a/Sources/LicensePlistCore/Entity/PlistInfo.swift
+++ b/Sources/LicensePlistCore/Entity/PlistInfo.swift
@@ -50,7 +50,7 @@ struct PlistInfo {
             manualLicenses.map { String(describing: $0) } +
             ["add-version-numbers: \(options.config.addVersionNumbers)", "LicensePlist Version: \(Consts.version)"])
             .joined(separator: "\n\n")
-        let savePath = options.outputPath.appendingPathComponent("\(Consts.prefix).latest_result.txt")
+        let savePath = options.outputPath.appendingPathComponent("\(options.prefix).latest_result.txt")
         if let previous = savePath.lp.read(), previous == contents, !config.force {
             Log.warning("Completed because no diff. You can execute force by `--force` flag.")
             exit(0)
@@ -86,15 +86,25 @@ struct PlistInfo {
     func outputPlist() {
         guard let licenses = licenses else { preconditionFailure() }
         let outputPath = options.outputPath
-        let itemsPath = outputPath.appendingPathComponent(Consts.prefix)
+        let itemsPath = outputPath.appendingPathComponent(options.prefix)
         if itemsPath.lp.deleteIfExits() {
-            Log.info("Deleted exiting plist within \(Consts.prefix)")
+            Log.info("Deleted exiting plist within \(options.prefix)")
         }
         itemsPath.lp.createDirectory()
         Log.info("Directory created: \(outputPath)")
 
-        let holder = LicensePlistHolder.load(licenses: licenses, config: options.config)
-        holder.write(to: outputPath.appendingPathComponent("\(Consts.prefix).plist"), itemsPath: itemsPath)
+        let holder = LicensePlistHolder.load(licenses: licenses, options: options)
+        holder.write(to: outputPath.appendingPathComponent("\(options.prefix).plist"), itemsPath: itemsPath)
+
+        if let markdownPath = options.markdownPath {
+            let markdownHolder = LicenseMarkdownHolder.load(licenses: licenses, options: options)
+            markdownHolder.write(to: markdownPath)
+        }
+
+        if let htmlPath = options.htmlPath {
+            let htmlHolder = LicenseHTMLHolder.load(licenses: licenses, options: options)
+            htmlHolder.write(to: htmlPath)
+        }
     }
 
     func reportMissings() {

--- a/Tests/LicensePlistTests/Entity/LicensePlistHolderTests.swift
+++ b/Tests/LicensePlistTests/Entity/LicensePlistHolderTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class LicensePlistHolderTests: XCTestCase {
     func testLoad_empty() {
-        let result = LicensePlistHolder.load(licenses: [], config: Config.empty)
+        let result = LicensePlistHolder.load(licenses: [], options: Options.empty)
         let (root, items) = result.deserialized()
         let rootItems = root["PreferenceSpecifiers"]!
         XCTAssertTrue(rootItems.isEmpty)
@@ -13,7 +13,7 @@ class LicensePlistHolderTests: XCTestCase {
     func testLoad_one() {
         let pods = CocoaPods(name: "name", nameSpecified: nil, version: nil)
         let podsLicense = CocoaPodsLicense(library: pods, body: "'<body>")
-        let result = LicensePlistHolder.load(licenses: [podsLicense], config: Config.empty)
+        let result = LicensePlistHolder.load(licenses: [podsLicense], options: Options.empty)
         let (root, items) = result.deserialized()
         let rootItems = root["PreferenceSpecifiers"]!
         XCTAssertEqual(rootItems.count, 1)


### PR DESCRIPTION
I liked the support for Markdown that Cocoapods gives so I added it but then from an Android project we get a HTML file so I've added that as another option too. I've also added the ability to change the prefix as it could look odd if distributed with an SDK.