### PR TITLE
Escape HTML entities in HTML output support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -56,6 +56,15 @@
         }
       },
       {
+        "package": "HTMLEntities",
+        "repositoryURL": "https://github.com/IBM-Swift/swift-html-entities.git",
+        "state": {
+          "branch": null,
+          "revision": "3b778b3ab061684db024eaf38c576887b42918aa",
+          "version": "3.0.13"
+        }
+      },
+      {
         "package": "Yaml",
         "repositoryURL": "https://github.com/behrang/YamlSwift.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,9 @@ let package = Package(
         .package(url: "https://github.com/IBM-Swift/HeliumLogger.git",
                  from: "1.8.0"),
         .package(url: "https://github.com/behrang/YamlSwift.git",
-                 from: "3.4.0")
+                 from: "3.4.0"),
+        .package(url: "https://github.com/IBM-Swift/swift-html-entities.git",
+                 from: "3.0.0")
     ],
     targets: [
         .target(
@@ -33,6 +35,7 @@ let package = Package(
                 "APIKit",
                 "Commander",
                 "HeliumLogger",
+                "HTMLEntities",
                 "Yaml"
             ]
         ),

--- a/Sources/LicensePlistCore/Entity/LicenseHTMLHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicenseHTMLHolder.swift
@@ -1,5 +1,6 @@
 import Foundation
 import LoggerAPI
+import HTMLEntities
 
 struct LicenseHTMLHolder {
     let html: String
@@ -20,8 +21,8 @@ struct LicenseHTMLHolder {
 """
         licenses.forEach { license in
             html += """
-        <h2>\(license.name(withVersion: options.config.addVersionNumbers))</h2>
-        <pre>\(license.body)</pre>
+        <h2>\(license.name(withVersion: options.config.addVersionNumbers).htmlEscape())</h2>
+        <pre>\(license.body.htmlEscape())</pre>
 
 """
         }


### PR DESCRIPTION
I tried to HTML output. Some license have HTML tag like string. It not rendered in WebView. (ex. `<COPYRIGHT HOLDER>`)
This PR, add HTML entity escape in library name and license text.