### PR TITLE
Support for iOS13

### DIFF
--- a/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
@@ -5,11 +5,14 @@ struct LicensePlistHolder {
     let root: Data
     let items: [(LicenseInfo, Data)]
     static func load(licenses: [LicenseInfo], options: Options) -> LicensePlistHolder {
-        let rootItems: [[String: String]] = licenses.map { license in
-            return ["Type": "PSChildPaneSpecifier",
-                    "Title": license.name(withVersion: options.config.addVersionNumbers),
-                    "File": "\(options.prefix)/\(license.name)"]
-        }
+        let rootItems: [[String: String]] = {
+            guard !licenses.isEmpty else { return [] }
+            return [["Type": "PSGroupSpecifier", "Title": "Licenses"]] + licenses.map { license in
+                return ["Type": "PSChildPaneSpecifier",
+                        "Title": license.name(withVersion: options.config.addVersionNumbers),
+                        "File": "\(options.prefix)/\(license.name)"]
+            }
+        }()
         let root = try! PropertyListSerialization.data(fromPropertyList: ["PreferenceSpecifiers": rootItems],
                                                        format: .xml,
                                                        options: 0)

--- a/Tests/LicensePlistTests/Entity/LicensePlistHolderTests.swift
+++ b/Tests/LicensePlistTests/Entity/LicensePlistHolderTests.swift
@@ -16,13 +16,17 @@ class LicensePlistHolderTests: XCTestCase {
         let result = LicensePlistHolder.load(licenses: [podsLicense], options: Options.empty)
         let (root, items) = result.deserialized()
         let rootItems = root["PreferenceSpecifiers"]!
-        XCTAssertEqual(rootItems.count, 1)
+        XCTAssertEqual(rootItems.count, 2)
         XCTAssertEqual(items.count, 1)
 
-        let rootItems1 = rootItems.first!
-        XCTAssertEqual(rootItems1["Type"], "PSChildPaneSpecifier")
-        XCTAssertEqual(rootItems1["Title"], "name")
-        XCTAssertEqual(rootItems1["File"], "com.mono0926.LicensePlist/name")
+        let rootItems1 = rootItems[0]
+        XCTAssertEqual(rootItems1["Type"], "PSGroupSpecifier")
+        XCTAssertEqual(rootItems1["Title"], "Licenses")
+
+        let rootItems2 = rootItems[1]
+        XCTAssertEqual(rootItems2["Type"], "PSChildPaneSpecifier")
+        XCTAssertEqual(rootItems2["Title"], "name")
+        XCTAssertEqual(rootItems2["File"], "com.mono0926.LicensePlist/name")
 
         let item1 = items.first!.1
         let item1_1 = item1["PreferenceSpecifiers"]!.first!


### PR DESCRIPTION
closed: #105 

`Type: PSGroupSpecifier` must be added to the first of licenses array.
I tested with iOS12, 13 and worked.

referenced: https://stackoverflow.com/a/58142496