### PR TITLE
Fixed optional Swift Package versions

### DIFF
--- a/Sources/LicensePlistCore/Entity/SwiftPackage.swift
+++ b/Sources/LicensePlistCore/Entity/SwiftPackage.swift
@@ -11,7 +11,7 @@ public struct SwiftPackage: Decodable, Equatable {
     struct State: Decodable, Equatable {
         let branch: String?
         let revision: String?
-        let version: String
+        let version: String?
     }
 
     let package: String

--- a/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
+++ b/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
@@ -32,6 +32,29 @@ class SwiftPackageManagerTests: XCTestCase {
         XCTAssertEqual(package.state.revision, "86d51ecee0bc0ebdb53fb69b11a24169a69097ba")
         XCTAssertEqual(package.state.version, "4.1.0")
     }
+    
+    func testDecodingOptionalVersion() {
+        let jsonString = """
+            {
+              "package": "APIKit",
+              "repositoryURL": "https://github.com/ishkawa/APIKit.git",
+              "state": {
+                "branch": "master",
+                "revision": "86d51ecee0bc0ebdb53fb69b11a24169a69097ba",
+                "version": null
+              }
+            }
+        """
+
+        let data = jsonString.data(using: .utf8)!
+        let package = try! JSONDecoder().decode(SwiftPackage.self, from: data)
+
+        XCTAssertEqual(package.package, "APIKit")
+        XCTAssertEqual(package.repositoryURL, "https://github.com/ishkawa/APIKit.git")
+        XCTAssertEqual(package.state.revision, "86d51ecee0bc0ebdb53fb69b11a24169a69097ba")
+        XCTAssertEqual(package.state.branch, "master")
+        XCTAssertEqual(package.state.version, nil)
+    }
 
     func testConvertToGithub() {
         let package = SwiftPackage(package: "Commander",


### PR DESCRIPTION
`Version` should be optional in case SPM refers to a branch such as "master". Currently having a single "null" version leads to an empty license array.