### PR TITLE
Set environment variable for GitHub token in default

### DIFF
--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -33,7 +33,7 @@ let main = command(Option("cartfile-path", default: Consts.cartfileName),
                                           podsPath: URL(fileURLWithPath: podsPath),
                                           packagePath: URL(fileURLWithPath: packagePath),
                                           prefix: prefix,
-                                          gitHubToken: gitHubToken.isEmpty ? nil : gitHubToken,
+                                          gitHubToken: gitHubToken.isEmpty ? ProcessInfo.processInfo.environment["LICENSE_PLIST_GITHUB_TOKEN"] : gitHubToken,
                                           htmlPath: htmlPath.isEmpty ? nil : URL(fileURLWithPath: htmlPath),
                                           markdownPath: markdownPath.isEmpty ? nil : URL(fileURLWithPath: markdownPath),
                                           config: config)


### PR DESCRIPTION
I want to use GitHub token as environment variable instead of `--github-token` command line option.

This PR makes following.
- If `--github-token` is set by command line, LicensePlist uses GitHub API with it as access token.
- Else, LicensePlist look for `LICENSE_PLIST_GITHUB_TOKEN` in environment.
  - If `LICENSE_PLIST_GITHUB_TOKEN` found, LicensePlist uses GitHub API with it as access token.
  - Else, LicensePlist uses GitHub API with no token.