### PR TITLE
Add feature that exports all licenses to the one page

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ You can see options by `license-plist --help`.
 - Default: false
 - Only when the files are created or updated, the terminal or the finder opens. By adding `--suppress-opening-directory` flag, this behavior is suppressed.
 
+#### `--export-all-to-root`
+
+- Default: false
+- All licenses are displayed in one page, not a list.
+
 ### Integrate into build
 
 Add a `Run Script Phase` to `Build Phases`:

--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -22,13 +22,15 @@ let main = command(Option("cartfile-path", default: Consts.cartfileName),
                    Option("markdown-path", default: ""),
                    Flag("force"),
                    Flag("add-version-numbers"),
-                   Flag("suppress-opening-directory")) { cartfile, podsPath, packagePath, xcodeprojPath, output, gitHubToken, configPath, prefix, htmlPath, markdownPath, force, version, suppressOpen in
+                   Flag("suppress-opening-directory"),
+                   Flag("export-all-to-root")) { cartfile, podsPath, packagePath, xcodeprojPath, output, gitHubToken, configPath, prefix, htmlPath, markdownPath, force, version, suppressOpen, exportAllToRoot in
 
                     Logger.configure()
                     var config = loadConfig(configPath: URL(fileURLWithPath: configPath))
                     config.force = force
                     config.addVersionNumbers = version
                     config.suppressOpeningDirectory = suppressOpen
+                    config.exportAllToRoot = exportAllToRoot
                     let options = Options(outputPath: URL(fileURLWithPath: output),
                                           cartfilePath: URL(fileURLWithPath: cartfile),
                                           podsPath: URL(fileURLWithPath: podsPath),

--- a/Sources/LicensePlistCore/Entity/Config.swift
+++ b/Sources/LicensePlistCore/Entity/Config.swift
@@ -10,6 +10,7 @@ public struct Config {
     public var force = false
     public var addVersionNumbers = false
     public var suppressOpeningDirectory = false
+    public var exportAllToRoot = false
 
     public static let empty = Config(githubs: [], manuals: [], excludes: [], renames: [:])
 

--- a/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
@@ -24,6 +24,24 @@ struct LicensePlistHolder {
         return LicensePlistHolder(root: root, items: items)
     }
 
+    static func loadAllToRoot(licenses: [LicenseInfo]) -> LicensePlistHolder {
+        let rootItem: [[String: String]] = {
+            guard !licenses.isEmpty else { return [] }
+            let body = licenses
+                .compactMap { lincense in
+                    return ["Type": "PSGroupSpecifier",
+                            "Title": lincense.name,
+                            "FooterText": lincense.body
+                            ]
+                }
+            return body
+        }()
+        let root = try! PropertyListSerialization.data(fromPropertyList: ["PreferenceSpecifiers": rootItem],
+                                                       format: .xml,
+                                                       options: 0)
+        return LicensePlistHolder(root: root, items: [])
+    }
+
     func deserialized() -> (root: [String: [[String: String]]], items: [(LicenseInfo, [String: [[String: String]]])]) {
         let root = try! PropertyListSerialization.propertyList(from: self.root, options: [], format: nil) as! [String: [[String: String]]]
         let items: [(LicenseInfo, [String: [[String: String]]])] = self.items.map { license, data in

--- a/Sources/LicensePlistCore/Entity/PlistInfo.swift
+++ b/Sources/LicensePlistCore/Entity/PlistInfo.swift
@@ -102,7 +102,9 @@ struct PlistInfo {
         itemsPath.lp.createDirectory()
         Log.info("Directory created: \(outputPath)")
 
-        let holder = LicensePlistHolder.load(licenses: licenses, options: options)
+        let holder = options.config.exportAllToRoot ?
+            LicensePlistHolder.loadAllToRoot(licenses: licenses) :
+            LicensePlistHolder.load(licenses: licenses, options: options)
         holder.write(to: outputPath.appendingPathComponent("\(options.prefix).plist"), itemsPath: itemsPath)
 
         if let markdownPath = options.markdownPath {

--- a/Tests/LicensePlistTests/Entity/LicensePlistHolderTests.swift
+++ b/Tests/LicensePlistTests/Entity/LicensePlistHolderTests.swift
@@ -33,4 +33,18 @@ class LicensePlistHolderTests: XCTestCase {
         XCTAssertEqual(item1_1["Type"], "PSGroupSpecifier")
         XCTAssertEqual(item1_1["FooterText"], "\'<body>")
     }
+    func testLoad_allToRoot() {
+        let pods = CocoaPods(name: "name", nameSpecified: nil, version: nil)
+        let podsLicense = CocoaPodsLicense(library: pods, body: "'<body>")
+        let result = LicensePlistHolder.loadAllToRoot(licenses: [podsLicense])
+        let (root, items) = result.deserialized()
+        let rootItems = root["PreferenceSpecifiers"]!
+        XCTAssertEqual(rootItems.count, 1)
+        XCTAssertEqual(items.count, 0)
+
+        let rootItems1 = rootItems[0]
+        XCTAssertEqual(rootItems1["Type"], "PSGroupSpecifier")
+        XCTAssertEqual(rootItems1["Title"], "name")
+        XCTAssertEqual(rootItems1["FooterText"], "'<body>")
+    }
 }


### PR DESCRIPTION
Hi @mono0926, thank you for this great program.

I add feature that exports all licenses to the one page.
If you think you need this feature, can you merge it?

This is sample.
![3_page](https://user-images.githubusercontent.com/19396988/69247120-3e623680-0bed-11ea-8561-80e7f0afb533.gif)

The reason for implementing this feature is as follows.

I had a problem. I use iOS13.2.3, License screen is crashed when back from library lisence screen.

![1_crush](https://user-images.githubusercontent.com/19396988/69238831-38178e80-0bdc-11ea-9a34-b2c0225e15a8.gif)

The first PSGroupSpecifier seems to be the cause. 

Second. I remove PSGroupSpecifier. That's seemed to perfect!! However, when the license screen of the library was displayed twice, the behavior became strange. ;;
![2_strange](https://user-images.githubusercontent.com/19396988/69239164-faffcc00-0bdc-11ea-8fbe-2724b88e98a6.gif)

