### PR TITLE
make config init public

### DIFF
--- a/Sources/LicensePlistCore/Entity/Config.swift
+++ b/Sources/LicensePlistCore/Entity/Config.swift
@@ -45,7 +45,7 @@ public struct Config {
         self = Config(githubs: githubsVersion + gitHubList, manuals: manualList, excludes: excludes, renames: renames)
     }
 
-    init(githubs: [GitHub], manuals: [Manual], excludes: [String], renames: [String: String]) {
+    public init(githubs: [GitHub], manuals: [Manual], excludes: [String], renames: [String: String]) {
         self.githubs = githubs
         self.manuals = manuals
         self.excludes = excludes

--- a/Sources/LicensePlistCore/Entity/Manual.swift
+++ b/Sources/LicensePlistCore/Entity/Manual.swift
@@ -10,7 +10,7 @@ public class Manual: Library {
     public var nameSpecified: String?
     public var version: String?
 
-    init(name n: String, source: String?, nameSpecified: String?, version: String?) {
+    public init(name n: String, source: String?, nameSpecified: String?, version: String?) {
         self.name = n
         self.source = source
         self.nameSpecified = nameSpecified


### PR DESCRIPTION
If the licenses are available in a different format then it's easier to use the regular init than the load from yaml init.