### PR TITLE
fix version number

### DIFF
--- a/Sources/LicensePlistCore/Consts.swift
+++ b/Sources/LicensePlistCore/Consts.swift
@@ -8,6 +8,6 @@ public struct Consts {
     public static let prefix = "com.mono0926.LicensePlist"
     public static let outputPath = "\(prefix).Output"
     public static let configPath = "license_plist.yml"
-    public static let version = "2.9.0"
+    public static let version = "2.11.2"
     public static let encoding = String.Encoding.utf8
 }

--- a/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
+++ b/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
@@ -83,7 +83,7 @@ class PlistInfoTests: XCTestCase {
         target.compareWithLatestSummary()
 
         XCTAssertEqual(target.summary,
-                       "add-version-numbers: false\n\nLicensePlist Version: 2.9.0")
+                       "add-version-numbers: false\n\nLicensePlist Version: 2.11.2")
         XCTAssertNotNil(target.summaryPath)
     }
 


### PR DESCRIPTION
I realized that version number is not change when LicensePlist installed after it was uninstalled.
Please check it. 