### PR TITLE
try to find Package.resolved located under xcworkspace

### DIFF
--- a/Sources/LicensePlistCore/LicensePlist.swift
+++ b/Sources/LicensePlistCore/LicensePlist.swift
@@ -66,7 +66,17 @@ private func readXcodeProject(path: URL) -> String? {
         .appendingPathComponent("xcshareddata")
         .appendingPathComponent("swiftpm")
         .appendingPathComponent("Package.resolved")
-    return readSwiftPackages(path: packageResolvedPath)
+    if packageResolvedPath.lp.isExists {
+        return readSwiftPackages(path: packageResolvedPath)
+    } else {
+        let packageResolvedPath = validatedPath
+        .deletingPathExtension()
+        .appendingPathExtension("xcworkspace")
+        .appendingPathComponent("xcshareddata")
+        .appendingPathComponent("swiftpm")
+        .appendingPathComponent("Package.resolved")
+        return readSwiftPackages(path: packageResolvedPath)
+    }
 }
 
 private func readPodsAcknowledgements(path: URL) -> [String] {


### PR DESCRIPTION
Hi @mono0926.

For SwiftPM users and CocoaPods users using Xcode 11.x. There is not Package.resolved file in `$PROJECT_FILE_PATH/project.xcworkspace/xcshareddata/swiftpm/`. Xcode generates Package.resolved under xcworkspace CocoaPods generates.

This PR will attempt to use the Package.resolved file under xcworkspace generated by CocoaPods if Package.resolved does not exist.