### PR TITLE
Add new parameter. --fail-if-missing-license

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/kylef/Commander.git",
         "state": {
           "branch": null,
-          "revision": "e5b50ad7b2e91eeb828393e89b03577b16be7db9",
-          "version": "0.8.0"
+          "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
+          "version": "0.9.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/HeliumLogger.git",
         "state": {
           "branch": null,
-          "revision": "779865e83149a59894b14950aa83f70b7e81bc27",
-          "version": "1.8.1"
+          "revision": "146a36c2a91270e4213fa7d7e8192cd2e55d0ace",
+          "version": "1.9.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
         "state": {
           "branch": null,
-          "revision": "e29073bb7cecf3673e56bcb16180e8fd0cb091f6",
-          "version": "1.8.1"
+          "revision": "3357dd9526cdf9436fa63bb792b669e6efdc43da",
+          "version": "1.9.0"
         }
       },
       {
@@ -60,8 +60,17 @@
         "repositoryURL": "https://github.com/IBM-Swift/swift-html-entities.git",
         "state": {
           "branch": null,
-          "revision": "3b778b3ab061684db024eaf38c576887b42918aa",
-          "version": "3.0.13"
+          "revision": "744c094976355aa96ca61b9b60ef0a38e979feb7",
+          "version": "3.0.14"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "eba9b323b5ba542c119ff17382a4ce737bcdc0b8",
+          "version": "0.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/kylef/Commander.git",
-                 from: "0.8.0"),
+                 from: "0.9.0"),
         .package(url: "https://github.com/ishkawa/APIKit.git",
                  from: "4.0.0"),
         .package(url: "https://github.com/IBM-Swift/HeliumLogger.git",

--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ You can see options by `license-plist --help`.
 - Default: false
 - All licenses are listed on a single page, not separated pages.
 
+#### `--fail-if-missing-license`
+
+- Default: false
+- If there is even one package for which a license cannot be found, LicensePlist returns exit code 1.
+
 ### Integrate into build
 
 Add a `Run Script Phase` to `Build Phases`:

--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -23,7 +23,8 @@ let main = command(Option("cartfile-path", default: Consts.cartfileName),
                    Flag("force"),
                    Flag("add-version-numbers"),
                    Flag("suppress-opening-directory"),
-                   Flag("single-page")) { cartfile, podsPath, packagePath, xcodeprojPath, output, gitHubToken, configPath, prefix, htmlPath, markdownPath, force, version, suppressOpen, singlePage in
+                   Flag("single-page"),
+                   Flag("fail-if-missing-license")) { cartfile, podsPath, packagePath, xcodeprojPath, output, gitHubToken, configPath, prefix, htmlPath, markdownPath, force, version, suppressOpen, singlePage, failIfMissingLicense in
 
                     Logger.configure()
                     var config = loadConfig(configPath: URL(fileURLWithPath: configPath))
@@ -31,6 +32,7 @@ let main = command(Option("cartfile-path", default: Consts.cartfileName),
                     config.addVersionNumbers = version
                     config.suppressOpeningDirectory = suppressOpen
                     config.singlePage = singlePage
+                    config.failIfMissingLicense = failIfMissingLicense
                     let options = Options(outputPath: URL(fileURLWithPath: output),
                                           cartfilePath: URL(fileURLWithPath: cartfile),
                                           podsPath: URL(fileURLWithPath: podsPath),

--- a/Sources/LicensePlistCore/Entity/Config.swift
+++ b/Sources/LicensePlistCore/Entity/Config.swift
@@ -11,6 +11,7 @@ public struct Config {
     public var addVersionNumbers = false
     public var suppressOpeningDirectory = false
     public var singlePage = false
+    public var failIfMissingLicense = false
 
     public static let empty = Config(githubs: [], manuals: [], excludes: [], renames: [:])
 

--- a/Sources/LicensePlistCore/Entity/PlistInfo.swift
+++ b/Sources/LicensePlistCore/Entity/PlistInfo.swift
@@ -126,8 +126,12 @@ struct PlistInfo {
         let missing = Set(githubLibraries.map { $0.name }).subtracting(Set(licenses.map { $0.name }))
         if missing.isEmpty {
             Log.info("None 🎉")
-        } else {
-            Array(missing).sorted { $0 < $1 }.forEach { Log.warning($0) }
+            return
+        }
+        
+        Array(missing).sorted { $0 < $1 }.forEach { Log.warning($0) }
+        if options.config.failIfMissingLicense {
+            exit(1)
         }
     }
 


### PR DESCRIPTION
I want to detect cases where license cannot be found.
I want to make an error when plist are not enough by github rate limit error.
This is an idea of adding a new parameter.