### PR TITLE
Split licences into multiple sections to avoid rendering issues

### DIFF
--- a/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
@@ -19,7 +19,7 @@ struct LicensePlistHolder {
         let items: [(LicenseInfo, Data)] = licenses.map { license in
             let item = ["PreferenceSpecifiers":
                 license.body.components(separatedBy: "\n\n").map { (paragraph) -> [String: String] in
-                    ["Type": "PSGroupSpecifier", "FooterText": paragraph.split(separator: "\n").joined(separator: " ")]
+                    ["Type": "PSGroupSpecifier", "FooterText": paragraph]
                 }
             ]
             let value = try! PropertyListSerialization.data(fromPropertyList: item, format: .xml, options: 0)

--- a/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
@@ -17,8 +17,17 @@ struct LicensePlistHolder {
                                                        format: .xml,
                                                        options: 0)
         let items: [(LicenseInfo, Data)] = licenses.map { license in
+            let lineRegex = try! NSRegularExpression(pattern: "^[-_*=]{3,}$", options: [])
             let item = ["PreferenceSpecifiers":
-                license.body.components(separatedBy: "\n\n").map { (paragraph) -> [String: String] in
+                            license.body
+                            .components(separatedBy: "\n\n")
+                            .split(whereSeparator: { (possibleHorizontalLine) -> Bool in
+                                lineRegex.firstMatch(in: possibleHorizontalLine, options: [], range: NSRange(location: 0, length: possibleHorizontalLine.count)) != nil
+                            })
+                            .map { parts in
+                                parts.joined(separator: "\n\n")
+                            }
+                            .map { (paragraph) -> [String: String] in
                     ["Type": "PSGroupSpecifier", "FooterText": paragraph]
                 }
             ]

--- a/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
@@ -17,7 +17,11 @@ struct LicensePlistHolder {
                                                        format: .xml,
                                                        options: 0)
         let items: [(LicenseInfo, Data)] = licenses.map { license in
-            let item = ["PreferenceSpecifiers": [["Type": "PSGroupSpecifier", "FooterText": license.body]]]
+            let item = ["PreferenceSpecifiers":
+                license.body.components(separatedBy: "\n\n").map { (paragraph) -> [String: String] in
+                    ["Type": "PSGroupSpecifier", "FooterText": paragraph.split(separator: "\n").joined(separator: " ")]
+                }
+            ]
             let value = try! PropertyListSerialization.data(fromPropertyList: item, format: .xml, options: 0)
             return (license, value)
         }

--- a/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
@@ -25,11 +25,12 @@ struct LicensePlistHolder {
                                 lineRegex.firstMatch(in: possibleHorizontalLine, options: [], range: NSRange(location: 0, length: possibleHorizontalLine.count)) != nil
                             })
                             .map { parts in
-                                parts.joined(separator: "\n\n")
+                                [parts.joined(separator: "\n\n")]
                             }
+                            .joined(separator: [String(repeating: "-", count: 40)])
                             .map { (paragraph) -> [String: String] in
-                    ["Type": "PSGroupSpecifier", "FooterText": paragraph]
-                }
+                                ["Type": "PSGroupSpecifier", "FooterText": paragraph]
+                            }
             ]
             let value = try! PropertyListSerialization.data(fromPropertyList: item, format: .xml, options: 0)
             return (license, value)

--- a/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
@@ -17,7 +17,7 @@ struct LicensePlistHolder {
                                                        format: .xml,
                                                        options: 0)
         let items: [(LicenseInfo, Data)] = licenses.map { license in
-            let lineRegex = try! NSRegularExpression(pattern: "^[-_*=]{3,}$", options: [])
+            let lineRegex = try! NSRegularExpression(pattern: "^\s*[-_*=]{3,}\s*$", options: [])
             let item = ["PreferenceSpecifiers":
                             license.body
                             .components(separatedBy: "\n\n")

--- a/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
@@ -17,7 +17,7 @@ struct LicensePlistHolder {
                                                        format: .xml,
                                                        options: 0)
         let items: [(LicenseInfo, Data)] = licenses.map { license in
-            let lineRegex = try! NSRegularExpression(pattern: "^\s*[-_*=]{3,}\s*$", options: [])
+            let lineRegex = try! NSRegularExpression(pattern: "^\\s*[-_*=]{3,}\\s*$", options: [])
             let item = ["PreferenceSpecifiers":
                             license.body
                             .components(separatedBy: "\n\n")

--- a/Tests/LicensePlistTests/Entity/LicensePlistHolderTests.swift
+++ b/Tests/LicensePlistTests/Entity/LicensePlistHolderTests.swift
@@ -47,4 +47,33 @@ class LicensePlistHolderTests: XCTestCase {
         XCTAssertEqual(rootItems1["Title"], "name")
         XCTAssertEqual(rootItems1["FooterText"], "'<body>")
     }
+    func testLoad_splitByHorizontalLine() {
+        let pods = CocoaPods(name: "name", nameSpecified: nil, version: nil)
+        let firstPart = "1\n2\n\n3\n---"
+        let secondPart = "a"
+        let thirdPart = "b"
+        let separator = String(repeating: "-", count: 40)
+        let podsLicense = CocoaPodsLicense(library: pods, body: "\(firstPart)\n\n\n---\n\n\(secondPart)\n\n==========\n\n\(thirdPart)")
+        let result = LicensePlistHolder.load(licenses: [podsLicense], options: Options.empty)
+        let (_, items) = result.deserialized()
+        
+        let item1 = items.first!.1
+        let groupArray = item1["PreferenceSpecifiers"]!
+        XCTAssertEqual(groupArray.count, 5)
+        let item1_0 = groupArray[0]
+        XCTAssertEqual(item1_0["Type"], "PSGroupSpecifier")
+        XCTAssertEqual(item1_0["FooterText"], firstPart)
+        let item1_1 = groupArray[1]
+        XCTAssertEqual(item1_1["Type"], "PSGroupSpecifier")
+        XCTAssertEqual(item1_1["FooterText"], separator)
+        let item1_2 = groupArray[2]
+        XCTAssertEqual(item1_2["Type"], "PSGroupSpecifier")
+        XCTAssertEqual(item1_2["FooterText"], secondPart)
+        let item1_3 = groupArray[3]
+        XCTAssertEqual(item1_3["Type"], "PSGroupSpecifier")
+        XCTAssertEqual(item1_3["FooterText"], separator)
+        let item1_4 = groupArray[4]
+        XCTAssertEqual(item1_4["Type"], "PSGroupSpecifier")
+        XCTAssertEqual(item1_4["FooterText"], thirdPart)
+    }
 }


### PR DESCRIPTION
This will only impact licences that contain horizontal line separators (at least 3 -_*= between two double linebreaks)

iOS14 has huge gaps between the groups, so splitting on every double linebreak would be overkill.

Resolves #138 