### PR TITLE
Setup GH Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: master
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: Cyberbeni/install-swift-tool@v2
+      with:
+        url: https://github.com/realm/SwiftLint
+        version: '*'
+    - run: swiftlint lint --strict .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,13 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: master
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: fastlane scan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,5 @@ jobs:
         url: https://github.com/thii/xcbeautify
         version: '*'
     - run: |
+        set -o pipefail
         swift test | xcbeautify

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,4 @@ jobs:
         version: '*'
     - run: |
         set -o pipefail
-        swift test | xcbeautify
+        swift test 2>&1 | xcbeautify

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,4 +10,8 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - run: fastlane scan
+    - uses: Cyberbeni/install-swift-tool@v2
+      with:
+        url: https://github.com/thii/xcbeautify
+        version: '*'
+    - run: swift test | xcbeautify

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,5 @@ jobs:
       with:
         url: https://github.com/thii/xcbeautify
         version: '*'
-    - run: swift test | xcbeautify
+    - run: |
+        swift test | xcbeautify

--- a/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
+++ b/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
@@ -143,7 +143,6 @@ class SwiftPackageManagerTests: XCTestCase {
 
     func testParse() {
         let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Package.resolved"
-        //let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Tests/LicensePlistTests/Resources/Package.resolved"
         let content = try! String(contentsOf: URL(string: path)!)
         let packages = SwiftPackage.loadPackages(content)
 


### PR DESCRIPTION
Based on activity, installing SwiftLint on Linux might not be better than just running it on macOS (it is preinstalled) as it will be cleared from the cache after 2 weeks. (But macOS minutes cost 10x more and macOS runners are more often delayed)

xcpretty is discontinued, so using xcbeautify instead, which is written in swift, so making bigger improvements to it doesn't require sweating blood.

Both SwiftLint and xcbeautify will load from cache if saved in a previous run and caching restrictions allow reloading it. https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache