### PR TITLE
Fix spm licenses gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Pods
 !Pods*.swift
 test_result_dir
 /.history
+Tests/LicensePlistTests/XcodeProjects/**/xcuserdata

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,7 @@ included:
   
 excluded:
   - Tests/LicensePlistTests/XcodeProjects
+  - Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
 
 line_length: 250
 nesting:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,6 +7,9 @@ disabled_rules:
 included:
   - Sources
   - Tests
+  
+excluded:
+  - Tests/LicensePlistTests/XcodeProjects
 
 line_length: 250
 nesting:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,7 +10,6 @@ included:
   
 excluded:
   - Tests/LicensePlistTests/XcodeProjects
-  - Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
 
 line_length: 250
 nesting:

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,12 @@ let package = Package(
                 "Yaml"
             ]
         ),
-        .testTarget(name: "LicensePlistTests", dependencies: ["LicensePlistCore"])
+        .testTarget(
+            name: "LicensePlistTests",
+            dependencies: ["LicensePlistCore"],
+            exclude: [
+                "XcodeProjects"
+            ]
+        )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can see options by `license-plist --help`.
 #### `--package-path`
 
 - Default: `Package.swift`
-- If you are using Swift Package Manager inside Xcode, you can use `--package-path $PROJECT_FILE_PATH/project.xcworkspace/xcshareddata/swiftpm/Package.swift` inside your `Run script`.
+- `LicensePlist` tries to find `YourProjectName.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` and `YourProjectName.xcworkspace/xcshareddata/swiftpm/Package.resolved`, then uses new one. If you make anothor workspace in custom directory,  you can use `--package-path PathToYourCustomWorkspace/CustomWorkspaceName.xcworkspace/xcshareddata/swiftpm/Package.swift` inside your `Run script`.
 
 #### `--output-path`
 

--- a/Sources/LicensePlistCore/Entity/FileReader/FileReader.swift
+++ b/Sources/LicensePlistCore/Entity/FileReader/FileReader.swift
@@ -17,6 +17,6 @@ protocol FileReader {
     var path: URL { get }
 
     /// Returns a concrete result by reading a file which the given path specifies.
-    func read() -> ResultType
+    func read() throws -> ResultType
 
 }

--- a/Sources/LicensePlistCore/Entity/FileReader/FileReader.swift
+++ b/Sources/LicensePlistCore/Entity/FileReader/FileReader.swift
@@ -1,0 +1,21 @@
+//
+//  FileReader.swift
+//  APIKit
+//
+//  Created by yosshi4486 on 2021/04/06.
+//
+
+import Foundation
+
+/// An object that reads any file from the given path.
+protocol FileReader {
+
+    /// The result parameter type of reading a file.
+    associatedtype ResultType
+
+    /// Returns a concrete result by reading a file which the given path specifies.
+    ///
+    /// - Parameter path: The path which the file located.
+    func read(path: URL) -> ResultType
+
+}

--- a/Sources/LicensePlistCore/Entity/FileReader/FileReader.swift
+++ b/Sources/LicensePlistCore/Entity/FileReader/FileReader.swift
@@ -1,6 +1,6 @@
 //
 //  FileReader.swift
-//  APIKit
+//  LicensePlistCore
 //
 //  Created by yosshi4486 on 2021/04/06.
 //
@@ -13,9 +13,10 @@ protocol FileReader {
     /// The result parameter type of reading a file.
     associatedtype ResultType
 
+    /// The path which an interested file located.
+    var path: URL { get }
+
     /// Returns a concrete result by reading a file which the given path specifies.
-    ///
-    /// - Parameter path: The path which the file located.
-    func read(path: URL) -> ResultType
+    func read() -> ResultType
 
 }

--- a/Sources/LicensePlistCore/Entity/FileReader/SwiftPackageFileReader.swift
+++ b/Sources/LicensePlistCore/Entity/FileReader/SwiftPackageFileReader.swift
@@ -1,0 +1,37 @@
+//
+//  SwiftPackageFileReader.swift
+//  LicensePlistCore
+//
+//  Created by yosshi4486 on 2021/04/06.
+//
+
+import Foundation
+
+/// An object that reads a Package.swift or Package.resolved file.
+struct SwiftPackageFileReader: FileReader {
+
+    struct FileReaderError: Swift.Error {
+        let path: URL
+
+        var localizedDescription: String? {
+            return "Invalide Package.swift name: \(path.lastPathComponent)"
+        }
+
+    }
+
+    typealias ResultType = String?
+
+    let path: URL
+
+    func read() throws -> String? {
+        if path.lastPathComponent != Consts.packageName && path.lastPathComponent != "Package.resolved" {
+            throw FileReaderError(path: path)
+        }
+
+        if let content = path.deletingPathExtension().appendingPathExtension("resolved").lp.read() {
+            return content
+        }
+        return path.lp.read()
+    }
+
+}

--- a/Sources/LicensePlistCore/Entity/FileReader/XcodeProjectFileReader.swift
+++ b/Sources/LicensePlistCore/Entity/FileReader/XcodeProjectFileReader.swift
@@ -25,7 +25,7 @@ struct XcodeProjectFileReader: FileReader {
         }
     }
 
-    func read() -> String? {
+    func read() throws -> String? {
         guard let validatedPath = projectPath else { return nil }
 
         if validatedPath.pathExtension != Consts.xcodeprojExtension {

--- a/Sources/LicensePlistCore/Entity/FileReader/XcodeProjectFileReader.swift
+++ b/Sources/LicensePlistCore/Entity/FileReader/XcodeProjectFileReader.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 /// An object that reads a xcodeproj file.
 struct XcodeProjectFileReader: FileReader {
 

--- a/Sources/LicensePlistCore/Entity/FileReader/XcodeProjectFileReader.swift
+++ b/Sources/LicensePlistCore/Entity/FileReader/XcodeProjectFileReader.swift
@@ -37,7 +37,7 @@ struct XcodeProjectFileReader: FileReader {
             .appendingPathComponent("swiftpm")
             .appendingPathComponent("Package.resolved")
         if packageResolvedPath.lp.isExists {
-            return readSwiftPackages(path: packageResolvedPath)
+            return try SwiftPackageFileReader(path: packageResolvedPath).read()
         } else {
             let packageResolvedPath = validatedPath
             .deletingPathExtension()
@@ -45,7 +45,7 @@ struct XcodeProjectFileReader: FileReader {
             .appendingPathComponent("xcshareddata")
             .appendingPathComponent("swiftpm")
             .appendingPathComponent("Package.resolved")
-            return readSwiftPackages(path: packageResolvedPath)
+            return try SwiftPackageFileReader(path: packageResolvedPath).read()
         }
     }
 

--- a/Sources/LicensePlistCore/Entity/FileReader/XcodeProjectFileReader.swift
+++ b/Sources/LicensePlistCore/Entity/FileReader/XcodeProjectFileReader.swift
@@ -7,13 +7,14 @@
 
 import Foundation
 
-/// An object that reads a  xcodeproj file.
+/// An object that reads a xcodeproj file.
 struct XcodeProjectFileReader: FileReader {
 
     typealias ResultType = String?
 
     let path: URL
 
+    /// The path which specifies "xcodeproj" file.
     var projectPath: URL? {
         if path.lastPathComponent.contains("*") {
             // find first "xcodeproj" in directory

--- a/Sources/LicensePlistCore/Entity/FileReader/XcodeProjectFileReader.swift
+++ b/Sources/LicensePlistCore/Entity/FileReader/XcodeProjectFileReader.swift
@@ -26,7 +26,27 @@ struct XcodeProjectFileReader: FileReader {
     }
 
     func read() -> String? {
-        return nil
+        guard let validatedPath = projectPath else { return nil }
+
+        if validatedPath.pathExtension != Consts.xcodeprojExtension {
+            return nil
+        }
+        let packageResolvedPath = validatedPath
+            .appendingPathComponent("project.xcworkspace")
+            .appendingPathComponent("xcshareddata")
+            .appendingPathComponent("swiftpm")
+            .appendingPathComponent("Package.resolved")
+        if packageResolvedPath.lp.isExists {
+            return readSwiftPackages(path: packageResolvedPath)
+        } else {
+            let packageResolvedPath = validatedPath
+            .deletingPathExtension()
+            .appendingPathExtension("xcworkspace")
+            .appendingPathComponent("xcshareddata")
+            .appendingPathComponent("swiftpm")
+            .appendingPathComponent("Package.resolved")
+            return readSwiftPackages(path: packageResolvedPath)
+        }
     }
 
 }

--- a/Sources/LicensePlistCore/Entity/FileReader/XcodeProjectFileReader.swift
+++ b/Sources/LicensePlistCore/Entity/FileReader/XcodeProjectFileReader.swift
@@ -1,0 +1,31 @@
+//
+//  XcodeProjectFileReader.swift
+//  LicensePlistCore
+//
+//  Created by yosshi4486 on 2021/04/06.
+//
+
+import Foundation
+
+/// An object that reads a  xcodeproj file.
+struct XcodeProjectFileReader: FileReader {
+
+    typealias ResultType = String?
+
+    let path: URL
+
+    var projectPath: URL? {
+        if path.lastPathComponent.contains("*") {
+            // find first "xcodeproj" in directory
+            return path.deletingLastPathComponent().lp.listDir().first { $0.pathExtension == Consts.xcodeprojExtension }
+        } else {
+            // use the specified path
+            return path
+        }
+    }
+
+    func read() -> String? {
+        return nil
+    }
+
+}

--- a/Sources/LicensePlistCore/Extension/URL.extension.swift
+++ b/Sources/LicensePlistCore/Extension/URL.extension.swift
@@ -88,6 +88,9 @@ extension LicensePlistExtension where Base == URL {
         assertionFailure(message)
         Log.error(message)
     }
+    internal var fileURL: URL {
+        return URL(fileURLWithPath: base.absoluteString)
+    }
 }
 
 protocol HasDefaultValue {

--- a/Sources/LicensePlistCore/LicensePlist.swift
+++ b/Sources/LicensePlistCore/LicensePlist.swift
@@ -54,7 +54,7 @@ private func readSwiftPackages(path: URL) -> String? {
     return path.lp.read()
 }
 
-private func readXcodeProject(path: URL) -> String? {
+func readXcodeProject(path: URL) -> String? {
 
     var projectPath: URL?
     if path.lastPathComponent.contains("*") {

--- a/Sources/LicensePlistCore/LicensePlist.swift
+++ b/Sources/LicensePlistCore/LicensePlist.swift
@@ -44,7 +44,7 @@ private func readMintfile(path: URL) -> GitHubLibraryConfigFile {
     return .mint(content: path.lp.read())
 }
 
-private func readSwiftPackages(path: URL) -> String? {
+func readSwiftPackages(path: URL) -> String? {
     if path.lastPathComponent != Consts.packageName && path.lastPathComponent != "Package.resolved" {
         fatalError("Invalid Package.swift name: \(path.lastPathComponent)")
     }

--- a/Sources/LicensePlistCore/LicensePlist.swift
+++ b/Sources/LicensePlistCore/LicensePlist.swift
@@ -12,7 +12,14 @@ public final class LicensePlist {
         info.loadCocoaPodsLicense(acknowledgements: readPodsAcknowledgements(path: options.podsPath))
         info.loadGitHubLibraries(file: readCartfile(path: options.cartfilePath))
         info.loadGitHubLibraries(file: readMintfile(path: options.mintfilePath))
-        info.loadSwiftPackageLibraries(packageFile: readSwiftPackages(path: options.packagePath) ?? readXcodeProject(path: options.xcodeprojPath))
+
+        do {
+            let swiftPackageFileReadResult = try SwiftPackageFileReader(path: options.packagePath).read()
+            let xcodeProjectFileReadResult = try XcodeProjectFileReader(path: options.xcodeprojPath).read()
+            info.loadSwiftPackageLibraries(packageFile: swiftPackageFileReadResult ?? xcodeProjectFileReadResult)
+        } catch {
+            fatalError(error.localizedDescription)
+        }
         info.loadManualLibraries()
         info.compareWithLatestSummary()
         info.downloadGitHubLicenses()
@@ -42,49 +49,6 @@ private func readMintfile(path: URL) -> GitHubLibraryConfigFile {
         fatalError("Invalid MintFile name: \(path.lastPathComponent)")
     }
     return .mint(content: path.lp.read())
-}
-
-func readSwiftPackages(path: URL) -> String? {
-    if path.lastPathComponent != Consts.packageName && path.lastPathComponent != "Package.resolved" {
-        fatalError("Invalid Package.swift name: \(path.lastPathComponent)")
-    }
-    if let content = path.deletingPathExtension().appendingPathExtension("resolved").lp.read() {
-        return content
-    }
-    return path.lp.read()
-}
-
-func readXcodeProject(path: URL) -> String? {
-
-    var projectPath: URL?
-    if path.lastPathComponent.contains("*") {
-        // find first "xcodeproj" in directory
-        projectPath = path.deletingLastPathComponent().lp.listDir().first { $0.pathExtension == Consts.xcodeprojExtension }
-    } else {
-        // use the specified path
-        projectPath = path
-    }
-    guard let validatedPath = projectPath else { return nil }
-
-    if validatedPath.pathExtension != Consts.xcodeprojExtension {
-        return nil
-    }
-    let packageResolvedPath = validatedPath
-        .appendingPathComponent("project.xcworkspace")
-        .appendingPathComponent("xcshareddata")
-        .appendingPathComponent("swiftpm")
-        .appendingPathComponent("Package.resolved")
-    if packageResolvedPath.lp.isExists {
-        return readSwiftPackages(path: packageResolvedPath)
-    } else {
-        let packageResolvedPath = validatedPath
-        .deletingPathExtension()
-        .appendingPathExtension("xcworkspace")
-        .appendingPathComponent("xcshareddata")
-        .appendingPathComponent("swiftpm")
-        .appendingPathComponent("Package.resolved")
-        return readSwiftPackages(path: packageResolvedPath)
-    }
 }
 
 private func readPodsAcknowledgements(path: URL) -> [String] {

--- a/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
@@ -112,7 +112,7 @@ class SwiftPackageFileReaderTests: XCTestCase {
 
     func testPackageSwift() throws {
         // Path for this package's Package.swift.
-        let packageSwiftPath = TestUtil.sourceDir.appendingPathComponent("Package.swift").fileURL
+        let packageSwiftPath = TestUtil.sourceDir.appendingPathComponent("Package.swift").lp.fileURL
         let reader = SwiftPackageFileReader(path: packageSwiftPath)
         XCTAssertEqual(
             try reader.read()?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -122,7 +122,7 @@ class SwiftPackageFileReaderTests: XCTestCase {
 
     func testPackageResolved() throws {
         // Path for this package's Package.resolved.
-        let packageResolvedPath = TestUtil.sourceDir.appendingPathComponent("Package.resolved").fileURL
+        let packageResolvedPath = TestUtil.sourceDir.appendingPathComponent("Package.resolved").lp.fileURL
         let reader = SwiftPackageFileReader(path: packageResolvedPath)
         XCTAssertEqual(
             try reader.read()?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
@@ -10,24 +10,7 @@ import XCTest
 
 class SwiftPackageFileReaderTests: XCTestCase {
 
-    var testURLBase: URL!
     var fileURL: URL!
-
-    var sourceDir: URL {
-        return URL(string: #file)!
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-    }
-
-    var testProjectsPath: URL {
-        return sourceDir
-            .appendingPathComponent("Tests")
-            .appendingPathComponent("LicensePlistTests")
-            .appendingPathComponent("XcodeProjects")
-    }
 
     var packageResolvedText: String {
         return #"""
@@ -114,8 +97,11 @@ class SwiftPackageFileReaderTests: XCTestCase {
     }
 
     override func setUpWithError() throws {
-        // The url deeply depends on this file location and XcodeProjects location. If any fix will be added, please fix this baseURL.
-        fileURL = URL(fileURLWithPath: "\(testProjectsPath)/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved")
+        fileURL = URL(fileURLWithPath: "\(TestUtil.testProjectsPath)/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved")
+    }
+
+    override func tearDownWithError() throws {
+        fileURL = nil
     }
 
     func testInvalidPath() throws {
@@ -126,7 +112,7 @@ class SwiftPackageFileReaderTests: XCTestCase {
 
     func testPackageSwift() throws {
         // Path for this package's Package.swift.
-        let packageSwiftPath = sourceDir.appendingPathComponent("Package.swift").fileURL
+        let packageSwiftPath = TestUtil.sourceDir.appendingPathComponent("Package.swift").fileURL
         let reader = SwiftPackageFileReader(path: packageSwiftPath)
         XCTAssertEqual(
             try reader.read()?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -136,7 +122,7 @@ class SwiftPackageFileReaderTests: XCTestCase {
 
     func testPackageResolved() throws {
         // Path for this package's Package.resolved.
-        let packageResolvedPath = sourceDir.appendingPathComponent("Package.resolved").fileURL
+        let packageResolvedPath = TestUtil.sourceDir.appendingPathComponent("Package.resolved").fileURL
         let reader = SwiftPackageFileReader(path: packageResolvedPath)
         XCTAssertEqual(
             try reader.read()?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -144,11 +130,4 @@ class SwiftPackageFileReaderTests: XCTestCase {
         )
     }
 
-}
-
-extension URL {
-
-    var fileURL: URL {
-        return URL(fileURLWithPath: self.absoluteString)
-    }
 }

--- a/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
@@ -1,0 +1,154 @@
+//
+//  SwiftPackageFileReaderTests.swift
+//  LicensePlistTests
+//
+//  Created by yosshi4486 on 2021/04/06.
+//
+
+import XCTest
+@testable import LicensePlistCore
+
+class SwiftPackageFileReaderTests: XCTestCase {
+
+    var testURLBase: URL!
+    var fileURL: URL!
+
+    var sourceDir: URL {
+        return URL(string: #file)!
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    var testProjectsPath: URL {
+        return sourceDir
+            .appendingPathComponent("Tests")
+            .appendingPathComponent("LicensePlistTests")
+            .appendingPathComponent("XcodeProjects")
+    }
+
+    var packageResolvedText: String {
+        return #"""
+        {
+          "object": {
+            "pins": [
+              {
+                "package": "APIKit",
+                "repositoryURL": "https://github.com/ishkawa/APIKit.git",
+                "state": {
+                  "branch": null,
+                  "revision": "86d51ecee0bc0ebdb53fb69b11a24169a69097ba",
+                  "version": "4.1.0"
+                }
+              },
+              {
+                "package": "HeliumLogger",
+                "repositoryURL": "https://github.com/IBM-Swift/HeliumLogger.git",
+                "state": {
+                  "branch": null,
+                  "revision": "146a36c2a91270e4213fa7d7e8192cd2e55d0ace",
+                  "version": "1.9.0"
+                }
+              },
+              {
+                "package": "LoggerAPI",
+                "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
+                "state": {
+                  "branch": null,
+                  "revision": "3357dd9526cdf9436fa63bb792b669e6efdc43da",
+                  "version": "1.9.0"
+                }
+              },
+              {
+                "package": "Result",
+                "repositoryURL": "https://github.com/antitypical/Result.git",
+                "state": {
+                  "branch": null,
+                  "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
+                  "version": "4.1.0"
+                }
+              },
+              {
+                "package": "swift-argument-parser",
+                "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+                "state": {
+                  "branch": null,
+                  "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
+                  "version": "0.3.1"
+                }
+              },
+              {
+                "package": "HTMLEntities",
+                "repositoryURL": "https://github.com/IBM-Swift/swift-html-entities.git",
+                "state": {
+                  "branch": null,
+                  "revision": "744c094976355aa96ca61b9b60ef0a38e979feb7",
+                  "version": "3.0.14"
+                }
+              },
+              {
+                "package": "swift-log",
+                "repositoryURL": "https://github.com/apple/swift-log.git",
+                "state": {
+                  "branch": null,
+                  "revision": "eba9b323b5ba542c119ff17382a4ce737bcdc0b8",
+                  "version": "0.0.0"
+                }
+              },
+              {
+                "package": "Yaml",
+                "repositoryURL": "https://github.com/behrang/YamlSwift.git",
+                "state": {
+                  "branch": null,
+                  "revision": "287f5cab7da0d92eb947b5fd8151b203ae04a9a3",
+                  "version": "3.4.4"
+                }
+              }
+            ]
+          },
+          "version": 1
+        }
+        """#
+    }
+
+    override func setUpWithError() throws {
+        // The url deeply depends on this file location and XcodeProjects location. If any fix will be added, please fix this baseURL.
+        fileURL = URL(fileURLWithPath: "\(testProjectsPath)/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved")
+    }
+
+    func testInvalidPath() throws {
+        let invalidFilePath = fileURL.deletingLastPathComponent().appendingPathComponent("Podfile.lock")
+        let reader = SwiftPackageFileReader(path: invalidFilePath)
+        XCTAssertThrowsError(try reader.read())
+    }
+
+    func testPackageSwift() throws {
+        // Path for this package's Package.swift.
+        let packageSwiftPath = sourceDir.appendingPathComponent("Package.swift").fileURL
+        let reader = SwiftPackageFileReader(path: packageSwiftPath)
+        XCTAssertEqual(
+            try reader.read()?.trimmingCharacters(in: .whitespacesAndNewlines),
+            packageResolvedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    func testPackageResolved() throws {
+        // Path for this package's Package.resolved.
+        let packageResolvedPath = sourceDir.appendingPathComponent("Package.resolved").fileURL
+        let reader = SwiftPackageFileReader(path: packageResolvedPath)
+        XCTAssertEqual(
+            try reader.read()?.trimmingCharacters(in: .whitespacesAndNewlines),
+            packageResolvedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+}
+
+extension URL {
+
+    var fileURL: URL {
+        return URL(fileURLWithPath: self.absoluteString)
+    }
+}

--- a/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
@@ -8,22 +8,43 @@
 import XCTest
 @testable import LicensePlistCore
 
+@available(OSX 10.11, *)
 class XcodeProjectFileReaderTests: XCTestCase {
 
+    var testURLBase: URL!
+    var fileURL: URL!
+    var wildcardFileURL: URL!
+
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        let testFilePath = #file
+
+        // The url deeply depends on this file location and XcodeProjects location. If any fix will be added, please fix this baseURL.
+        let baseURL = URL(string: testFilePath)!
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("XcodeProjects")
+
+        fileURL = URL(fileURLWithPath: "\(baseURL)/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj")
+        wildcardFileURL = URL(fileURLWithPath: "\(baseURL)/SwiftPackageManagerTestProject/*")
+
+        print("fileURL: \(String(describing: fileURL))")
+        print("wildcardURL: \(String(describing: wildcardFileURL))")
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        fileURL = nil
+        wildcardFileURL = nil
     }
 
-    func testReadXcodeProject() throws {
-        #warning("TODO: This should be replcased to \"https://github.com/yosshi4486/LicensePlist/mono0926/master/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj\" until I create pull request.")
+    func testProjectPathWhenSpecifiesCorrectFilePath() throws {
+        let fileReader = XcodeProjectFileReader(path: fileURL)
+        XCTAssertEqual(fileReader.projectPath, fileURL)
+    }
 
-        let githubXcodeprojURL = URL(string: "https://github.com/yosshi4486/LicensePlist/tree/fix-spm-licenses-gen/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj")!
-        let result = readXcodeProject(path: githubXcodeprojURL)
-        XCTAssertNotNil(result)
+    func testProjectPathWhenSpecifiesWildcard() throws {
+        let fileReader = XcodeProjectFileReader(path: wildcardFileURL)
+        XCTAssertEqual(fileReader.projectPath, fileURL)
     }
 
 }

--- a/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
@@ -42,7 +42,7 @@ class XcodeProjectFileReaderTests: XCTestCase {
         XCTAssertNotNil(try fileReader.read())
     }
 
-    func testReadPackageResolved() throws {
+    func testOldPackageResolvedNotUsed() throws {
         let fileReader = XcodeProjectFileReader(path: projectFileURL)
         let expected = #"""
         {
@@ -107,11 +107,92 @@ class XcodeProjectFileReaderTests: XCTestCase {
           "version": 1
         }
         """#
+        XCTAssertNotEqual(
+            try fileReader.read()?.trimmingCharacters(in: .whitespacesAndNewlines),
+            expected.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    func testNewPackageResolvedUsed() throws {
+        let fileReader = XcodeProjectFileReader(path: projectFileURL)
+        let expected = #"""
+        {
+          "object": {
+            "pins": [
+              {
+                "package": "APIKit",
+                "repositoryURL": "https://github.com/ishkawa/APIKit",
+                "state": {
+                  "branch": null,
+                  "revision": "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4",
+                  "version": "5.2.0"
+                }
+              },
+              {
+                "package": "Commander",
+                "repositoryURL": "https://github.com/kylef/Commander.git",
+                "state": {
+                  "branch": null,
+                  "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
+                  "version": "0.9.1"
+                }
+              },
+              {
+                "package": "Kingfisher",
+                "repositoryURL": "https://github.com/onevcat/Kingfisher",
+                "state": {
+                  "branch": null,
+                  "revision": "bbc4bc4def7eb05a7ba8e1219f80ee9be327334e",
+                  "version": "6.2.1"
+                }
+              },
+              {
+                "package": "rswift",
+                "repositoryURL": "https://github.com/mac-cain13/R.swift",
+                "state": {
+                  "branch": null,
+                  "revision": "18ad905c6f8f0865042e1d1ee4effc7291aa899d",
+                  "version": "5.4.0"
+                }
+              },
+              {
+                "package": "Spectre",
+                "repositoryURL": "https://github.com/kylef/Spectre.git",
+                "state": {
+                  "branch": null,
+                  "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
+                  "version": "0.9.2"
+                }
+              },
+              {
+                "package": "Swinject",
+                "repositoryURL": "https://github.com/Swinject/Swinject",
+                "state": {
+                  "branch": null,
+                  "revision": "8a76d2c74bafbb455763487cc6a08e91bad1f78b",
+                  "version": "2.7.1"
+                }
+              },
+              {
+                "package": "XcodeEdit",
+                "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit",
+                "state": {
+                  "branch": null,
+                  "revision": "dab519997ca05833470c88f0926b27498911ecbf",
+                  "version": "2.7.7"
+                }
+              }
+            ]
+          },
+          "version": 1
+        }
+        """#
         XCTAssertEqual(
             try fileReader.read()?.trimmingCharacters(in: .whitespacesAndNewlines),
             expected.trimmingCharacters(in: .whitespacesAndNewlines)
         )
     }
+
 
     /// Test Xcode update either xcodeproj one or the other one.
     ///

--- a/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
@@ -193,7 +193,6 @@ class XcodeProjectFileReaderTests: XCTestCase {
         )
     }
 
-
     /// Test Xcode update either xcodeproj one or the other one.
     ///
     /// The problem is occured when developer adds additional xcworkspace from the middle of project processt.
@@ -211,7 +210,6 @@ class XcodeProjectFileReaderTests: XCTestCase {
             .appendingPathComponent("xcshareddata")
             .appendingPathComponent("swiftpm")
             .appendingPathComponent("Package.resolved")
-
 
         // URLResourceKey
         // https://developer.apple.com/documentation/foundation/urlresourcekey

--- a/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
@@ -117,7 +117,6 @@ class XcodeProjectFileReaderTests: XCTestCase {
     ///
     /// The problem is occured when developer adds additional xcworkspace from the middle of project processt.
     /// Licenses should be latest, but this behaviour cause unlisted OSS software.
-    @available(OSX 10.14, *)
     func testTwoDifferentPackageResolvedAreExist() throws {
         let projectXcworkspacePackageResolvedFileURL = projectFileURL!
             .appendingPathComponent("project.xcworkspace")
@@ -132,18 +131,19 @@ class XcodeProjectFileReaderTests: XCTestCase {
             .appendingPathComponent("swiftpm")
             .appendingPathComponent("Package.resolved")
 
-        let fileManager = FileManager()
 
-        let projectPackageResolvedFileAttributes = try fileManager.attributesOfItem(atPath: projectXcworkspacePackageResolvedFileURL.url.absoluteString)
-        let cocoapodPackageResolvedFileAttributes = try fileManager.attributesOfItem(atPath: cocoapodsXcworkspacePackageResolvedFIleURL.url.absoluteString)
+        // URLResourceKey
+        // https://developer.apple.com/documentation/foundation/urlresourcekey
 
-        // FileAttributeKey
-        // https://developer.apple.com/documentation/foundation/fileattributekey
+        let projectPackageResolvedFileModificationDate = try projectXcworkspacePackageResolvedFileURL
+            .resourceValues(forKeys: [.attributeModificationDateKey])
+            .attributeModificationDate
 
-        XCTAssertNotEqual(
-            try XCTUnwrap(projectPackageResolvedFileAttributes[.modificationDate] as? Date),
-            try XCTUnwrap(cocoapodPackageResolvedFileAttributes[.modificationDate] as? Date)
-        )
+        let cocoapodPackageResolvedFileModificationDate = try cocoapodsXcworkspacePackageResolvedFIleURL
+            .resourceValues(forKeys: [.attributeModificationDateKey])
+            .attributeModificationDate
+
+        XCTAssertNotEqual(projectPackageResolvedFileModificationDate, cocoapodPackageResolvedFileModificationDate)
     }
 
 }

--- a/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
@@ -49,7 +49,7 @@ class XcodeProjectFileReaderTests: XCTestCase {
 
     func testReadNotNil() throws {
         let fileReader = XcodeProjectFileReader(path: fileURL)
-        XCTAssertNotNil(fileReader.read())
+        XCTAssertNotNil(try fileReader.read())
     }
 
     func testReadPackageResolved() throws {
@@ -118,7 +118,7 @@ class XcodeProjectFileReaderTests: XCTestCase {
         }
         """#
         XCTAssertEqual(
-            fileReader.read()?.trimmingCharacters(in: .whitespacesAndNewlines),
+            try fileReader.read()?.trimmingCharacters(in: .whitespacesAndNewlines),
             expected.trimmingCharacters(in: .whitespacesAndNewlines)
         )
     }

--- a/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
@@ -1,0 +1,29 @@
+//
+//  XcodeProjectFileReaderTests.swift
+//  LicensePlistTests
+//
+//  Created by yosshi4486 on 2021/04/06.
+//
+
+import XCTest
+@testable import LicensePlistCore
+
+class XcodeProjectFileReaderTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testReadXcodeProject() throws {
+        #warning("TODO: This should be replcased to \"https://github.com/yosshi4486/LicensePlist/mono0926/master/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj\" until I create pull request.")
+
+        let githubXcodeprojURL = URL(string: "https://github.com/yosshi4486/LicensePlist/tree/fix-spm-licenses-gen/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj")!
+        let result = readXcodeProject(path: githubXcodeprojURL)
+        XCTAssertNotNil(result)
+    }
+
+}

--- a/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
@@ -44,153 +44,16 @@ class XcodeProjectFileReaderTests: XCTestCase {
 
     func testOldPackageResolvedNotUsed() throws {
         let fileReader = XcodeProjectFileReader(path: projectFileURL)
-        let expected = #"""
-        {
-          "object": {
-            "pins": [
-              {
-                "package": "APIKit",
-                "repositoryURL": "https://github.com/ishkawa/APIKit",
-                "state": {
-                  "branch": null,
-                  "revision": "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4",
-                  "version": "5.2.0"
-                }
-              },
-              {
-                "package": "Commander",
-                "repositoryURL": "https://github.com/kylef/Commander.git",
-                "state": {
-                  "branch": null,
-                  "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
-                  "version": "0.9.1"
-                }
-              },
-              {
-                "package": "rswift",
-                "repositoryURL": "https://github.com/mac-cain13/R.swift",
-                "state": {
-                  "branch": null,
-                  "revision": "18ad905c6f8f0865042e1d1ee4effc7291aa899d",
-                  "version": "5.4.0"
-                }
-              },
-              {
-                "package": "Spectre",
-                "repositoryURL": "https://github.com/kylef/Spectre.git",
-                "state": {
-                  "branch": null,
-                  "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
-                  "version": "0.9.2"
-                }
-              },
-              {
-                "package": "Swinject",
-                "repositoryURL": "https://github.com/Swinject/Swinject",
-                "state": {
-                  "branch": null,
-                  "revision": "8a76d2c74bafbb455763487cc6a08e91bad1f78b",
-                  "version": "2.7.1"
-                }
-              },
-              {
-                "package": "XcodeEdit",
-                "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit",
-                "state": {
-                  "branch": null,
-                  "revision": "dab519997ca05833470c88f0926b27498911ecbf",
-                  "version": "2.7.7"
-                }
-              }
-            ]
-          },
-          "version": 1
-        }
-        """#
-        XCTAssertNotEqual(
-            try fileReader.read()?.trimmingCharacters(in: .whitespacesAndNewlines),
-            expected.trimmingCharacters(in: .whitespacesAndNewlines)
-        )
+        let data = try Data(contentsOf: TestUtil.testResourceDir.appendingPathComponent("OldExpectedPackage.resolved").lp.fileURL)
+        let oldExpectedPackageResolved = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertNotEqual(try fileReader.read(), oldExpectedPackageResolved)
     }
 
     func testNewPackageResolvedUsed() throws {
         let fileReader = XcodeProjectFileReader(path: projectFileURL)
-        let expected = #"""
-        {
-          "object": {
-            "pins": [
-              {
-                "package": "APIKit",
-                "repositoryURL": "https://github.com/ishkawa/APIKit",
-                "state": {
-                  "branch": null,
-                  "revision": "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4",
-                  "version": "5.2.0"
-                }
-              },
-              {
-                "package": "Commander",
-                "repositoryURL": "https://github.com/kylef/Commander.git",
-                "state": {
-                  "branch": null,
-                  "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
-                  "version": "0.9.1"
-                }
-              },
-              {
-                "package": "Kingfisher",
-                "repositoryURL": "https://github.com/onevcat/Kingfisher",
-                "state": {
-                  "branch": null,
-                  "revision": "bbc4bc4def7eb05a7ba8e1219f80ee9be327334e",
-                  "version": "6.2.1"
-                }
-              },
-              {
-                "package": "rswift",
-                "repositoryURL": "https://github.com/mac-cain13/R.swift",
-                "state": {
-                  "branch": null,
-                  "revision": "18ad905c6f8f0865042e1d1ee4effc7291aa899d",
-                  "version": "5.4.0"
-                }
-              },
-              {
-                "package": "Spectre",
-                "repositoryURL": "https://github.com/kylef/Spectre.git",
-                "state": {
-                  "branch": null,
-                  "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
-                  "version": "0.9.2"
-                }
-              },
-              {
-                "package": "Swinject",
-                "repositoryURL": "https://github.com/Swinject/Swinject",
-                "state": {
-                  "branch": null,
-                  "revision": "8a76d2c74bafbb455763487cc6a08e91bad1f78b",
-                  "version": "2.7.1"
-                }
-              },
-              {
-                "package": "XcodeEdit",
-                "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit",
-                "state": {
-                  "branch": null,
-                  "revision": "dab519997ca05833470c88f0926b27498911ecbf",
-                  "version": "2.7.7"
-                }
-              }
-            ]
-          },
-          "version": 1
-        }
-        """#
-        XCTAssertEqual(
-            try fileReader.read()?.trimmingCharacters(in: .whitespacesAndNewlines),
-            expected.trimmingCharacters(in: .whitespacesAndNewlines)
-        )
+        let data = try Data(contentsOf: TestUtil.testResourceDir.appendingPathComponent("NewExpectedPackage.resolved").lp.fileURL)
+        let newExpectedPackageResolved = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertEqual(try fileReader.read(), newExpectedPackageResolved)
     }
 
     /// Test Xcode update either xcodeproj one or the other one.

--- a/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
@@ -47,4 +47,80 @@ class XcodeProjectFileReaderTests: XCTestCase {
         XCTAssertEqual(fileReader.projectPath, fileURL)
     }
 
+    func testReadNotNil() throws {
+        let fileReader = XcodeProjectFileReader(path: fileURL)
+        XCTAssertNotNil(fileReader.read())
+    }
+
+    func testReadPackageResolved() throws {
+        let fileReader = XcodeProjectFileReader(path: fileURL)
+        let expected = #"""
+        {
+          "object": {
+            "pins": [
+              {
+                "package": "APIKit",
+                "repositoryURL": "https://github.com/ishkawa/APIKit",
+                "state": {
+                  "branch": null,
+                  "revision": "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4",
+                  "version": "5.2.0"
+                }
+              },
+              {
+                "package": "Commander",
+                "repositoryURL": "https://github.com/kylef/Commander.git",
+                "state": {
+                  "branch": null,
+                  "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
+                  "version": "0.9.1"
+                }
+              },
+              {
+                "package": "rswift",
+                "repositoryURL": "https://github.com/mac-cain13/R.swift",
+                "state": {
+                  "branch": null,
+                  "revision": "18ad905c6f8f0865042e1d1ee4effc7291aa899d",
+                  "version": "5.4.0"
+                }
+              },
+              {
+                "package": "Spectre",
+                "repositoryURL": "https://github.com/kylef/Spectre.git",
+                "state": {
+                  "branch": null,
+                  "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
+                  "version": "0.9.2"
+                }
+              },
+              {
+                "package": "Swinject",
+                "repositoryURL": "https://github.com/Swinject/Swinject",
+                "state": {
+                  "branch": null,
+                  "revision": "8a76d2c74bafbb455763487cc6a08e91bad1f78b",
+                  "version": "2.7.1"
+                }
+              },
+              {
+                "package": "XcodeEdit",
+                "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit",
+                "state": {
+                  "branch": null,
+                  "revision": "dab519997ca05833470c88f0926b27498911ecbf",
+                  "version": "2.7.7"
+                }
+              }
+            ]
+          },
+          "version": 1
+        }
+        """#
+        XCTAssertEqual(
+            fileReader.read()?.trimmingCharacters(in: .whitespacesAndNewlines),
+            expected.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
 }

--- a/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
@@ -11,22 +11,12 @@ import XCTest
 @available(OSX 10.11, *)
 class XcodeProjectFileReaderTests: XCTestCase {
 
-    var testURLBase: URL!
     var fileURL: URL!
     var wildcardFileURL: URL!
 
     override func setUpWithError() throws {
-        let testFilePath = #file
-
-        // The url deeply depends on this file location and XcodeProjects location. If any fix will be added, please fix this baseURL.
-        let baseURL = URL(string: testFilePath)!
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("XcodeProjects")
-
-        fileURL = URL(fileURLWithPath: "\(baseURL)/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj")
-        wildcardFileURL = URL(fileURLWithPath: "\(baseURL)/SwiftPackageManagerTestProject/*")
+        fileURL = URL(fileURLWithPath: "\(TestUtil.testProjectsPath)/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj")
+        wildcardFileURL = URL(fileURLWithPath: "\(TestUtil.testProjectsPath)/SwiftPackageManagerTestProject/*")
 
         print("fileURL: \(String(describing: fileURL))")
         print("wildcardURL: \(String(describing: wildcardFileURL))")

--- a/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
+++ b/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
@@ -143,7 +143,7 @@ class SwiftPackageManagerTests: XCTestCase {
 
     func testParse() {
         let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Package.resolved"
-        //let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Tests/LicensePlistTests/Resources/Package.resolved"
+        // let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Tests/LicensePlistTests/Resources/Package.resolved"
         let content = try! String(contentsOf: URL(string: path)!)
         let packages = SwiftPackage.loadPackages(content)
 

--- a/Tests/LicensePlistTests/Extension/URL.extensionTests.swift
+++ b/Tests/LicensePlistTests/Extension/URL.extensionTests.swift
@@ -8,4 +8,8 @@ class URLExtensionTests: XCTestCase {
         let url = URL(string: "https://raw.githubusercontent.com/mono0926/LicensePlist/master/LICENSE")!
         XCTAssertTrue(url.lp.download().resultSync().value!.hasPrefix("MIT License"))
     }
+    func testFileURL() throws {
+        let url = URL(string: "/github.com/mono0926/LicensePlist")!
+        XCTAssertEqual(url.lp.fileURL.absoluteString, "file:///github.com/mono0926/LicensePlist")
+    }
 }

--- a/Tests/LicensePlistTests/Resources/NewExpectedPackage.resolved
+++ b/Tests/LicensePlistTests/Resources/NewExpectedPackage.resolved
@@ -1,0 +1,70 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "APIKit",
+        "repositoryURL": "https://github.com/ishkawa/APIKit",
+        "state": {
+          "branch": null,
+          "revision": "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4",
+          "version": "5.2.0"
+        }
+      },
+      {
+        "package": "Commander",
+        "repositoryURL": "https://github.com/kylef/Commander.git",
+        "state": {
+          "branch": null,
+          "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
+          "version": "0.9.1"
+        }
+      },
+      {
+        "package": "Kingfisher",
+        "repositoryURL": "https://github.com/onevcat/Kingfisher",
+        "state": {
+          "branch": null,
+          "revision": "bbc4bc4def7eb05a7ba8e1219f80ee9be327334e",
+          "version": "6.2.1"
+        }
+      },
+      {
+        "package": "rswift",
+        "repositoryURL": "https://github.com/mac-cain13/R.swift",
+        "state": {
+          "branch": null,
+          "revision": "18ad905c6f8f0865042e1d1ee4effc7291aa899d",
+          "version": "5.4.0"
+        }
+      },
+      {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
+          "version": "0.9.2"
+        }
+      },
+      {
+        "package": "Swinject",
+        "repositoryURL": "https://github.com/Swinject/Swinject",
+        "state": {
+          "branch": null,
+          "revision": "8a76d2c74bafbb455763487cc6a08e91bad1f78b",
+          "version": "2.7.1"
+        }
+      },
+      {
+        "package": "XcodeEdit",
+        "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit",
+        "state": {
+          "branch": null,
+          "revision": "dab519997ca05833470c88f0926b27498911ecbf",
+          "version": "2.7.7"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Tests/LicensePlistTests/Resources/OldExpectedPackage.resolved
+++ b/Tests/LicensePlistTests/Resources/OldExpectedPackage.resolved
@@ -1,0 +1,61 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "APIKit",
+        "repositoryURL": "https://github.com/ishkawa/APIKit",
+        "state": {
+          "branch": null,
+          "revision": "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4",
+          "version": "5.2.0"
+        }
+      },
+      {
+        "package": "Commander",
+        "repositoryURL": "https://github.com/kylef/Commander.git",
+        "state": {
+          "branch": null,
+          "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
+          "version": "0.9.1"
+        }
+      },
+      {
+        "package": "rswift",
+        "repositoryURL": "https://github.com/mac-cain13/R.swift",
+        "state": {
+          "branch": null,
+          "revision": "18ad905c6f8f0865042e1d1ee4effc7291aa899d",
+          "version": "5.4.0"
+        }
+      },
+      {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
+          "version": "0.9.2"
+        }
+      },
+      {
+        "package": "Swinject",
+        "repositoryURL": "https://github.com/Swinject/Swinject",
+        "state": {
+          "branch": null,
+          "revision": "8a76d2c74bafbb455763487cc6a08e91bad1f78b",
+          "version": "2.7.1"
+        }
+      },
+      {
+        "package": "XcodeEdit",
+        "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit",
+        "state": {
+          "branch": null,
+          "revision": "dab519997ca05833470c88f0926b27498911ecbf",
+          "version": "2.7.7"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Tests/LicensePlistTests/TestUtil.swift
+++ b/Tests/LicensePlistTests/TestUtil.swift
@@ -3,7 +3,7 @@ import LoggerAPI
 @testable import LicensePlistCore
 
 class TestUtil {
-    
+
     static func setGitHubToken() {
         // Specify your `github_token.txt` location
         let url = URL(fileURLWithPath: "/Users/mono/Git/LicensePlist/Tests/LicensePlistTests/Resources/github_token.txt")

--- a/Tests/LicensePlistTests/TestUtil.swift
+++ b/Tests/LicensePlistTests/TestUtil.swift
@@ -22,6 +22,13 @@ class TestUtil {
             .deletingLastPathComponent()
     }
 
+    static var testResourceDir: URL {
+        return sourceDir
+            .appendingPathComponent("Tests")
+            .appendingPathComponent("LicensePlistTests")
+            .appendingPathComponent("Resources")
+    }
+
     static var testProjectsPath: URL {
         return sourceDir
             .appendingPathComponent("Tests")

--- a/Tests/LicensePlistTests/TestUtil.swift
+++ b/Tests/LicensePlistTests/TestUtil.swift
@@ -3,6 +3,7 @@ import LoggerAPI
 @testable import LicensePlistCore
 
 class TestUtil {
+    
     static func setGitHubToken() {
         // Specify your `github_token.txt` location
         let url = URL(fileURLWithPath: "/Users/mono/Git/LicensePlist/Tests/LicensePlistTests/Resources/github_token.txt")
@@ -13,4 +14,27 @@ class TestUtil {
             Log.warning("\(url) not found. You can execute without github_token, but API limit will exceed sometimes.")
         }
     }
+
+    static var sourceDir: URL {
+        return URL(string: #file)!
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    static var testProjectsPath: URL {
+        return sourceDir
+            .appendingPathComponent("Tests")
+            .appendingPathComponent("LicensePlistTests")
+            .appendingPathComponent("XcodeProjects")
+    }
+
+}
+
+extension URL {
+
+    var fileURL: URL {
+        return URL(fileURLWithPath: self.absoluteString)
+    }
+
 }

--- a/Tests/LicensePlistTests/TestUtil.swift
+++ b/Tests/LicensePlistTests/TestUtil.swift
@@ -30,19 +30,3 @@ class TestUtil {
     }
 
 }
-
-extension URL {
-
-    var fileURL: URL {
-        var components = URLComponents(string: self.absoluteString)!
-        components.scheme = "file:///"
-        return components.url!
-    }
-
-    var url: URL {
-        var components = URLComponents(string: self.absoluteString)!
-        components.scheme = nil
-        return components.url!
-    }
-
-}

--- a/Tests/LicensePlistTests/TestUtil.swift
+++ b/Tests/LicensePlistTests/TestUtil.swift
@@ -34,7 +34,15 @@ class TestUtil {
 extension URL {
 
     var fileURL: URL {
-        return URL(fileURLWithPath: self.absoluteString)
+        var components = URLComponents(string: self.absoluteString)!
+        components.scheme = "file:///"
+        return components.url!
+    }
+
+    var url: URL {
+        var components = URLComponents(string: self.absoluteString)!
+        components.scheme = nil
+        return components.url!
     }
 
 }

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/Podfile
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/Podfile
@@ -1,0 +1,11 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'SwiftPackageManagerTestProject' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for SwiftPackageManagerTestProject
+  pod 'LicensePlist'
+
+end

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/Podfile.lock
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - LicensePlist (3.0.5)
+
+DEPENDENCIES:
+  - LicensePlist
+
+SPEC REPOS:
+  trunk:
+    - LicensePlist
+
+SPEC CHECKSUMS:
+  LicensePlist: 11c638fa9dc22ddb5771cdf910242ae1ba2684da
+
+PODFILE CHECKSUM: 8378b751a3bd9576bc108a11d2a213dd15564f13
+
+COCOAPODS: 1.10.1

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.pbxproj
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.pbxproj
@@ -1,0 +1,344 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		181A7378261BEB870010A791 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 181A7377261BEB870010A791 /* AppDelegate.swift */; };
+		181A737A261BEB870010A791 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 181A7379261BEB870010A791 /* SceneDelegate.swift */; };
+		181A737C261BEB870010A791 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 181A737B261BEB870010A791 /* ViewController.swift */; };
+		181A737F261BEB870010A791 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 181A737D261BEB870010A791 /* Main.storyboard */; };
+		181A7381261BEB880010A791 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 181A7380261BEB880010A791 /* Assets.xcassets */; };
+		181A7384261BEB880010A791 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 181A7382261BEB880010A791 /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		181A7374261BEB870010A791 /* SwiftPackageManagerTestProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftPackageManagerTestProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		181A7377261BEB870010A791 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		181A7379261BEB870010A791 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		181A737B261BEB870010A791 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		181A737E261BEB870010A791 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		181A7380261BEB880010A791 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		181A7383261BEB880010A791 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		181A7385261BEB880010A791 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		181A7371261BEB870010A791 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		181A736B261BEB870010A791 = {
+			isa = PBXGroup;
+			children = (
+				181A7376261BEB870010A791 /* SwiftPackageManagerTestProject */,
+				181A7375261BEB870010A791 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		181A7375261BEB870010A791 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				181A7374261BEB870010A791 /* SwiftPackageManagerTestProject.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		181A7376261BEB870010A791 /* SwiftPackageManagerTestProject */ = {
+			isa = PBXGroup;
+			children = (
+				181A7377261BEB870010A791 /* AppDelegate.swift */,
+				181A7379261BEB870010A791 /* SceneDelegate.swift */,
+				181A737B261BEB870010A791 /* ViewController.swift */,
+				181A737D261BEB870010A791 /* Main.storyboard */,
+				181A7380261BEB880010A791 /* Assets.xcassets */,
+				181A7382261BEB880010A791 /* LaunchScreen.storyboard */,
+				181A7385261BEB880010A791 /* Info.plist */,
+			);
+			path = SwiftPackageManagerTestProject;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		181A7373261BEB870010A791 /* SwiftPackageManagerTestProject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 181A7388261BEB880010A791 /* Build configuration list for PBXNativeTarget "SwiftPackageManagerTestProject" */;
+			buildPhases = (
+				181A7370261BEB870010A791 /* Sources */,
+				181A7371261BEB870010A791 /* Frameworks */,
+				181A7372261BEB870010A791 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftPackageManagerTestProject;
+			productName = SwiftPackageManagerTestProject;
+			productReference = 181A7374261BEB870010A791 /* SwiftPackageManagerTestProject.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		181A736C261BEB870010A791 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					181A7373261BEB870010A791 = {
+						CreatedOnToolsVersion = 12.4;
+					};
+				};
+			};
+			buildConfigurationList = 181A736F261BEB870010A791 /* Build configuration list for PBXProject "SwiftPackageManagerTestProject" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 181A736B261BEB870010A791;
+			productRefGroup = 181A7375261BEB870010A791 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				181A7373261BEB870010A791 /* SwiftPackageManagerTestProject */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		181A7372261BEB870010A791 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				181A7384261BEB880010A791 /* LaunchScreen.storyboard in Resources */,
+				181A7381261BEB880010A791 /* Assets.xcassets in Resources */,
+				181A737F261BEB870010A791 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		181A7370261BEB870010A791 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				181A737C261BEB870010A791 /* ViewController.swift in Sources */,
+				181A7378261BEB870010A791 /* AppDelegate.swift in Sources */,
+				181A737A261BEB870010A791 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		181A737D261BEB870010A791 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				181A737E261BEB870010A791 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		181A7382261BEB880010A791 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				181A7383261BEB880010A791 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		181A7386261BEB880010A791 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		181A7387261BEB880010A791 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		181A7389261BEB880010A791 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = SwiftPackageManagerTestProject/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = LicensePlist.SwiftPackageManagerTestProject;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		181A738A261BEB880010A791 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = SwiftPackageManagerTestProject/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = LicensePlist.SwiftPackageManagerTestProject;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		181A736F261BEB870010A791 /* Build configuration list for PBXProject "SwiftPackageManagerTestProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				181A7386261BEB880010A791 /* Debug */,
+				181A7387261BEB880010A791 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		181A7388261BEB880010A791 /* Build configuration list for PBXNativeTarget "SwiftPackageManagerTestProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				181A7389261BEB880010A791 /* Debug */,
+				181A738A261BEB880010A791 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 181A736C261BEB870010A791 /* Project object */;
+}

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.pbxproj
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -13,6 +13,8 @@
 		181A737F261BEB870010A791 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 181A737D261BEB870010A791 /* Main.storyboard */; };
 		181A7381261BEB880010A791 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 181A7380261BEB880010A791 /* Assets.xcassets */; };
 		181A7384261BEB880010A791 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 181A7382261BEB880010A791 /* LaunchScreen.storyboard */; };
+		181A738E261BED020010A791 /* APIKit in Frameworks */ = {isa = PBXBuildFile; productRef = 181A738D261BED020010A791 /* APIKit */; };
+		181A7394261BED2C0010A791 /* Swinject in Frameworks */ = {isa = PBXBuildFile; productRef = 181A7393261BED2C0010A791 /* Swinject */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +33,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				181A738E261BED020010A791 /* APIKit in Frameworks */,
+				181A7394261BED2C0010A791 /* Swinject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -83,6 +87,10 @@
 			dependencies = (
 			);
 			name = SwiftPackageManagerTestProject;
+			packageProductDependencies = (
+				181A738D261BED020010A791 /* APIKit */,
+				181A7393261BED2C0010A791 /* Swinject */,
+			);
 			productName = SwiftPackageManagerTestProject;
 			productReference = 181A7374261BEB870010A791 /* SwiftPackageManagerTestProject.app */;
 			productType = "com.apple.product-type.application";
@@ -110,6 +118,11 @@
 				Base,
 			);
 			mainGroup = 181A736B261BEB870010A791;
+			packageReferences = (
+				181A738C261BED020010A791 /* XCRemoteSwiftPackageReference "APIKit" */,
+				181A7390261BED140010A791 /* XCRemoteSwiftPackageReference "R" */,
+				181A7392261BED2C0010A791 /* XCRemoteSwiftPackageReference "Swinject" */,
+			);
 			productRefGroup = 181A7375261BEB870010A791 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -339,6 +352,46 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		181A738C261BED020010A791 /* XCRemoteSwiftPackageReference "APIKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ishkawa/APIKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.2.0;
+			};
+		};
+		181A7390261BED140010A791 /* XCRemoteSwiftPackageReference "R" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mac-cain13/R.swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.4.0;
+			};
+		};
+		181A7392261BED2C0010A791 /* XCRemoteSwiftPackageReference "Swinject" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Swinject/Swinject";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.7.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		181A738D261BED020010A791 /* APIKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 181A738C261BED020010A791 /* XCRemoteSwiftPackageReference "APIKit" */;
+			productName = APIKit;
+		};
+		181A7393261BED2C0010A791 /* Swinject */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 181A7392261BED2C0010A791 /* XCRemoteSwiftPackageReference "Swinject" */;
+			productName = Swinject;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 181A736C261BEB870010A791 /* Project object */;
 }

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.pbxproj
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.pbxproj
@@ -15,9 +15,12 @@
 		181A7384261BEB880010A791 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 181A7382261BEB880010A791 /* LaunchScreen.storyboard */; };
 		181A738E261BED020010A791 /* APIKit in Frameworks */ = {isa = PBXBuildFile; productRef = 181A738D261BED020010A791 /* APIKit */; };
 		181A7394261BED2C0010A791 /* Swinject in Frameworks */ = {isa = PBXBuildFile; productRef = 181A7393261BED2C0010A791 /* Swinject */; };
+		181A7501261C25AE0010A791 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 181A7500261C25AE0010A791 /* Kingfisher */; };
+		DEA2D016D17021DD0BE94AE8 /* Pods_SwiftPackageManagerTestProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D264460E93BB4CD0E77E02AD /* Pods_SwiftPackageManagerTestProject.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0E824DA88D148AACE86EA348 /* Pods-SwiftPackageManagerTestProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftPackageManagerTestProject.debug.xcconfig"; path = "Target Support Files/Pods-SwiftPackageManagerTestProject/Pods-SwiftPackageManagerTestProject.debug.xcconfig"; sourceTree = "<group>"; };
 		181A7374261BEB870010A791 /* SwiftPackageManagerTestProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftPackageManagerTestProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		181A7377261BEB870010A791 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		181A7379261BEB870010A791 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -26,6 +29,8 @@
 		181A7380261BEB880010A791 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		181A7383261BEB880010A791 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		181A7385261BEB880010A791 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1E8FAAB559E7E08FCBB3B3D2 /* Pods-SwiftPackageManagerTestProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftPackageManagerTestProject.release.xcconfig"; path = "Target Support Files/Pods-SwiftPackageManagerTestProject/Pods-SwiftPackageManagerTestProject.release.xcconfig"; sourceTree = "<group>"; };
+		D264460E93BB4CD0E77E02AD /* Pods_SwiftPackageManagerTestProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftPackageManagerTestProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -33,8 +38,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				181A7501261C25AE0010A791 /* Kingfisher in Frameworks */,
 				181A738E261BED020010A791 /* APIKit in Frameworks */,
 				181A7394261BED2C0010A791 /* Swinject in Frameworks */,
+				DEA2D016D17021DD0BE94AE8 /* Pods_SwiftPackageManagerTestProject.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -46,6 +53,8 @@
 			children = (
 				181A7376261BEB870010A791 /* SwiftPackageManagerTestProject */,
 				181A7375261BEB870010A791 /* Products */,
+				457D5F9A8DBFE8564B9EFD4A /* Pods */,
+				A8A5C05B0578E01CF9FDE92D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -71,6 +80,23 @@
 			path = SwiftPackageManagerTestProject;
 			sourceTree = "<group>";
 		};
+		457D5F9A8DBFE8564B9EFD4A /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				0E824DA88D148AACE86EA348 /* Pods-SwiftPackageManagerTestProject.debug.xcconfig */,
+				1E8FAAB559E7E08FCBB3B3D2 /* Pods-SwiftPackageManagerTestProject.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		A8A5C05B0578E01CF9FDE92D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D264460E93BB4CD0E77E02AD /* Pods_SwiftPackageManagerTestProject.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -78,6 +104,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 181A7388261BEB880010A791 /* Build configuration list for PBXNativeTarget "SwiftPackageManagerTestProject" */;
 			buildPhases = (
+				851DDC7A17B1A42CB6B9F644 /* [CP] Check Pods Manifest.lock */,
 				181A7370261BEB870010A791 /* Sources */,
 				181A7371261BEB870010A791 /* Frameworks */,
 				181A7372261BEB870010A791 /* Resources */,
@@ -90,6 +117,7 @@
 			packageProductDependencies = (
 				181A738D261BED020010A791 /* APIKit */,
 				181A7393261BED2C0010A791 /* Swinject */,
+				181A7500261C25AE0010A791 /* Kingfisher */,
 			);
 			productName = SwiftPackageManagerTestProject;
 			productReference = 181A7374261BEB870010A791 /* SwiftPackageManagerTestProject.app */;
@@ -122,6 +150,7 @@
 				181A738C261BED020010A791 /* XCRemoteSwiftPackageReference "APIKit" */,
 				181A7390261BED140010A791 /* XCRemoteSwiftPackageReference "R" */,
 				181A7392261BED2C0010A791 /* XCRemoteSwiftPackageReference "Swinject" */,
+				181A74FF261C25AE0010A791 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 			);
 			productRefGroup = 181A7375261BEB870010A791 /* Products */;
 			projectDirPath = "";
@@ -144,6 +173,31 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		851DDC7A17B1A42CB6B9F644 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-SwiftPackageManagerTestProject-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		181A7370261BEB870010A791 /* Sources */ = {
@@ -296,6 +350,7 @@
 		};
 		181A7389261BEB880010A791 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0E824DA88D148AACE86EA348 /* Pods-SwiftPackageManagerTestProject.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -314,6 +369,7 @@
 		};
 		181A738A261BEB880010A791 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1E8FAAB559E7E08FCBB3B3D2 /* Pods-SwiftPackageManagerTestProject.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -378,6 +434,14 @@
 				minimumVersion = 2.7.1;
 			};
 		};
+		181A74FF261C25AE0010A791 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/onevcat/Kingfisher";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.2.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -390,6 +454,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 181A7392261BED2C0010A791 /* XCRemoteSwiftPackageReference "Swinject" */;
 			productName = Swinject;
+		};
+		181A7500261C25AE0010A791 /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 181A74FF261C25AE0010A791 /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,61 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "APIKit",
+        "repositoryURL": "https://github.com/ishkawa/APIKit",
+        "state": {
+          "branch": null,
+          "revision": "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4",
+          "version": "5.2.0"
+        }
+      },
+      {
+        "package": "Commander",
+        "repositoryURL": "https://github.com/kylef/Commander.git",
+        "state": {
+          "branch": null,
+          "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
+          "version": "0.9.1"
+        }
+      },
+      {
+        "package": "rswift",
+        "repositoryURL": "https://github.com/mac-cain13/R.swift",
+        "state": {
+          "branch": null,
+          "revision": "18ad905c6f8f0865042e1d1ee4effc7291aa899d",
+          "version": "5.4.0"
+        }
+      },
+      {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
+          "version": "0.9.2"
+        }
+      },
+      {
+        "package": "Swinject",
+        "repositoryURL": "https://github.com/Swinject/Swinject",
+        "state": {
+          "branch": null,
+          "revision": "8a76d2c74bafbb455763487cc6a08e91bad1f78b",
+          "version": "2.7.1"
+        }
+      },
+      {
+        "package": "XcodeEdit",
+        "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit",
+        "state": {
+          "branch": null,
+          "revision": "dab519997ca05833470c88f0926b27498911ecbf",
+          "version": "2.7.7"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcworkspace/contents.xcworkspacedata
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:SwiftPackageManagerTestProject.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,70 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "APIKit",
+        "repositoryURL": "https://github.com/ishkawa/APIKit",
+        "state": {
+          "branch": null,
+          "revision": "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4",
+          "version": "5.2.0"
+        }
+      },
+      {
+        "package": "Commander",
+        "repositoryURL": "https://github.com/kylef/Commander.git",
+        "state": {
+          "branch": null,
+          "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
+          "version": "0.9.1"
+        }
+      },
+      {
+        "package": "Kingfisher",
+        "repositoryURL": "https://github.com/onevcat/Kingfisher",
+        "state": {
+          "branch": null,
+          "revision": "bbc4bc4def7eb05a7ba8e1219f80ee9be327334e",
+          "version": "6.2.1"
+        }
+      },
+      {
+        "package": "rswift",
+        "repositoryURL": "https://github.com/mac-cain13/R.swift",
+        "state": {
+          "branch": null,
+          "revision": "18ad905c6f8f0865042e1d1ee4effc7291aa899d",
+          "version": "5.4.0"
+        }
+      },
+      {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
+          "version": "0.9.2"
+        }
+      },
+      {
+        "package": "Swinject",
+        "repositoryURL": "https://github.com/Swinject/Swinject",
+        "state": {
+          "branch": null,
+          "revision": "8a76d2c74bafbb455763487cc6a08e91bad1f78b",
+          "version": "2.7.1"
+        }
+      },
+      {
+        "package": "XcodeEdit",
+        "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit",
+        "state": {
+          "branch": null,
+          "revision": "dab519997ca05833470c88f0926b27498911ecbf",
+          "version": "2.7.7"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/AppDelegate.swift
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  SwiftPackageManagerTestProject
+//
+//  Created by yosshi4486 on 2021/04/06.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/Assets.xcassets/Contents.json
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/Base.lproj/LaunchScreen.storyboard
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/Base.lproj/Main.storyboard
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/Info.plist
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/Info.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/SceneDelegate.swift
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  SwiftPackageManagerTestProject
+//
+//  Created by yosshi4486 on 2021/04/06.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/ViewController.swift
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject/ViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  SwiftPackageManagerTestProject
+//
+//  Created by yosshi4486 on 2021/04/06.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+

--- a/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/WORKAROUND.md
+++ b/Tests/LicensePlistTests/XcodeProjects/SwiftPackageManagerTestProject/WORKAROUND.md
@@ -1,0 +1,2 @@
+# WORKAROUND
+Avoiding this swift package error(https://stackoverflow.com/questions/51540665/swift-package-manager-mixed-language-source-files), Pods directory must not be added in this XcodeProjects/ path.


### PR DESCRIPTION
# About
I fixed swift package license's generation issue.

# What happen?
I had encountered issue that LicensePlist doesn't generate swift package licenses.

# Why does the problem occur?
Xcode has its own project.xcworkspace in its subdirectory, and developer can add additional xcworkspace, in most cases it is via Cocoapods.

## Reason
Either project.xcworkspace's Package.resolved or YourAdded.xcworkspace's Package.resolved is updated. Not both. Implementation of swift package integration in this repository didn't care the behavior, so **old Package.resolved is referred in some situations.**

# How did you solve it?
Compare modification dates of these files.
(Sources/LicensePlistCore/Entity/FileReader/XcodeProjectFileReader.swift)

```swift
guard
    let xcodeprojPackageResolvedModifiedDate = try xcodeprojPackageResolvedPath
        .resourceValues(forKeys: [.attributeModificationDateKey])
        .attributeModificationDate,
    let xcworkspacePackageResolveModifiedDate = try xcworkspacePackageResolvedPath
        .resourceValues(forKeys: [.attributeModificationDateKey])
        .attributeModificationDate
else {
    return try SwiftPackageFileReader(path: defaultPath).read()
}

if xcworkspacePackageResolveModifiedDate >= xcodeprojPackageResolvedModifiedDate {
    return try SwiftPackageFileReader(path: xcworkspacePackageResolvedPath).read()
} else {
    return try SwiftPackageFileReader(path: xcodeprojPackageResolvedPath).read()
}
```

# How did you implement it?
1. Add test xcode project under Tests/LicensePlistTests/XcodeProjects.
2. Refactor private "readXxx" methods to FileReader objects for improving testability.
3. Test them.
4. Fix the problem.

# Who encounter the problem?
A developer who used swift package in early stage of product development, and added cocoapods integration later.

# Review Points
🙅‍♂️Changes from Tests/LicensePlistTests/XcodeProjects are not important, They are only test resource files.
🙆‍♂️Changes from Sources/LicensePlistCore/Entity/FileReader and Tests/LicensePlistTests/Entity/FileReader are important. They are core implementations and tests about this PR.

# Pass tests?
I run all tests locally by cmd +U.

# Related issues?
#140

# Other things?
If maintainers allow the refactoring of FileReader, I'd like to rewrite other "readXxx" functions in next pr.