### PR TITLE
Fix packaged resolution conflict with other packages depending on swift-argument-parser

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git",
-                 from: "0.4.2"),
+                 from: "0.3.2"),
         .package(url: "https://github.com/ishkawa/APIKit.git",
                  from: "5.2.0"),
         .package(url: "https://github.com/Kitura/HeliumLogger.git",


### PR DESCRIPTION
Lower the required version of swift-argument-parser to avoid dependency resolution conflicts.

> Failed to resolve dependencies because SwiftLint 0.43.1 depends on swift-argument-parser 0.3.1..<0.4.0 and LicensePlist >=3.0.9 depends on swift-argument-parser 0.4.2..<1.0.0, 
> SwiftLint is incompatible with LicensePlist. 
> And because root depends on LicensePlist 3.11.0 and root depends on SwiftLint 0.43.1, version solving failed.

The dependency still resolves to the latest (0.4.2) if no other dependencies require lesser versions of swift-argument-parser. LicensePlist works fine with both the latest 0.4.x versions and older 0.3.x versions of swift-argument-parser 