### PR TITLE
Safely unwrap options in tests

### DIFF
--- a/Tests/LicensePlistTests/Entity/CocoaPodsTests.swift
+++ b/Tests/LicensePlistTests/Entity/CocoaPodsTests.swift
@@ -9,18 +9,18 @@ class CocoaPodsTests: XCTestCase {
         XCTAssertTrue(results.isEmpty)
     }
 
-    func testParse() {
+    func testParse() throws {
         let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Tests/LicensePlistTests/Resources/acknowledgements.plist"
-        let content = try! String(contentsOf: URL(string: path)!)
+        let content = try String(contentsOf: XCTUnwrap(URL(string: path)))
         let results = CocoaPodsLicense.load(content,
                                             versionInfo: VersionInfo(dictionary: ["Firebase": "1.2.3"]),
                                             config: Config(githubs: [], manuals: [], excludes: [], renames: ["Firebase": "Firebase2"]))
         XCTAssertFalse(results.isEmpty)
         XCTAssertEqual(results.count, 11)
-        let licenseFirst = results.first!
+        let licenseFirst = try XCTUnwrap(results.first)
         XCTAssertEqual(licenseFirst.library, CocoaPods(name: "Firebase", nameSpecified: "Firebase2", version: "1.2.3"))
         XCTAssertEqual(licenseFirst.body, "Copyright 2017 Google")
-        let licenseLast = results.last!
+        let licenseLast = try XCTUnwrap(results.last)
         XCTAssertEqual(licenseLast.library, CocoaPods(name: "Protobuf", nameSpecified: nil, version: nil))
         XCTAssertTrue(licenseLast.body.hasPrefix("This license applies to all parts of Protocol Buffers except the following:"))
     }

--- a/Tests/LicensePlistTests/Entity/ConfigTests.swift
+++ b/Tests/LicensePlistTests/Entity/ConfigTests.swift
@@ -7,9 +7,9 @@ class ConfigTests: XCTestCase {
     func testInit_empty_yaml() {
         XCTAssertEqual(Config(yaml: "", configBasePath: URL(fileURLWithPath: "")), Config(githubs: [], manuals: [], excludes: [], renames: [:]))
     }
-    func testInit_sample() {
-        let url = URL(string: "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Tests/LicensePlistTests/Resources/license_plist.yml")!
-        XCTAssertEqual(Config(yaml: try! url.lp.download().resultSync().get(), configBasePath: url.deletingLastPathComponent()),
+    func testInit_sample() throws {
+        let url = try XCTUnwrap(URL(string: "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Tests/LicensePlistTests/Resources/license_plist.yml"))
+        XCTAssertEqual(Config(yaml: try url.lp.download().resultSync().get(), configBasePath: url.deletingLastPathComponent()),
                        Config(githubs: [GitHub(name: "LicensePlist", nameSpecified: "License Plist", owner: "mono0926", version: "1.2.0"),
                                         GitHub(name: "NativePopup", nameSpecified: nil, owner: "mono0926", version: nil)],
                               manuals: [Manual(name: "WebRTC",

--- a/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/XcodeProjectFileReaderTests.swift
@@ -58,10 +58,10 @@ class XcodeProjectFileReaderTests: XCTestCase {
 
     /// Test Xcode update either xcodeproj one or the other one.
     ///
-    /// The problem is occured when developer adds additional xcworkspace from the middle of project processt.
-    /// Licenses should be latest, but this behaviour cause unlisted OSS software.
+    /// The problem is occurred when developer adds additional xcworkspace from the middle of project process.
+    /// Licenses should be latest, but this behavior cause unlisted OSS software.
     func testTwoDifferentPackageResolvedAreExist() throws {
-        let projectXcworkspacePackageResolvedFileURL = projectFileURL!
+        let projectXcworkspacePackageResolvedFileURL = try XCTUnwrap(projectFileURL)
             .appendingPathComponent("project.xcworkspace")
             .appendingPathComponent("xcshareddata")
             .appendingPathComponent("swiftpm")

--- a/Tests/LicensePlistTests/Entity/GitHubLicense.collectorTests.swift
+++ b/Tests/LicensePlistTests/Entity/GitHubLicense.collectorTests.swift
@@ -10,17 +10,17 @@ class GitHubLicenseTests: XCTestCase {
         TestUtil.setGitHubToken()
     }
 
-    func testCollect() {
+    func testCollect() throws {
         let carthage = GitHub(name: "NativePopup", nameSpecified: nil, owner: "mono0926", version: nil)
-        let license = try! GitHubLicense.download(carthage).resultSync().get()
+        let license = try GitHubLicense.download(carthage).resultSync().get()
         XCTAssertEqual(license.library, carthage)
         XCTAssertTrue(license.body.hasPrefix("MIT License"))
         XCTAssertEqual(license.githubResponse.kind.spdxId, "MIT")
     }
 
-    func testCollect_forked() {
+    func testCollect_forked() throws {
         let carthage = GitHub(name: "vapor", nameSpecified: nil, owner: "mono0926", version: nil)
-        let license = try! GitHubLicense.download(carthage).resultSync().get()
+        let license = try GitHubLicense.download(carthage).resultSync().get()
         XCTAssertEqual(license.library, carthage)
         XCTAssertTrue(license.body.hasPrefix("The MIT License (MIT)"))
         XCTAssertEqual(license.githubResponse.kind.spdxId, "MIT")

--- a/Tests/LicensePlistTests/Entity/LicensePlistHolderTests.swift
+++ b/Tests/LicensePlistTests/Entity/LicensePlistHolderTests.swift
@@ -3,19 +3,19 @@ import XCTest
 @testable import LicensePlistCore
 
 class LicensePlistHolderTests: XCTestCase {
-    func testLoad_empty() {
+    func testLoad_empty() throws {
         let result = LicensePlistHolder.load(licenses: [], options: Options.empty)
         let (root, items) = result.deserialized()
-        let rootItems = root["PreferenceSpecifiers"]!
+        let rootItems = try XCTUnwrap(root["PreferenceSpecifiers"])
         XCTAssertTrue(rootItems.isEmpty)
         XCTAssertTrue(items.isEmpty)
     }
-    func testLoad_one() {
+    func testLoad_one() throws {
         let pods = CocoaPods(name: "name", nameSpecified: nil, version: nil)
         let podsLicense = CocoaPodsLicense(library: pods, body: "'<body>")
         let result = LicensePlistHolder.load(licenses: [podsLicense], options: Options.empty)
         let (root, items) = result.deserialized()
-        let rootItems = root["PreferenceSpecifiers"]!
+        let rootItems = try XCTUnwrap(root["PreferenceSpecifiers"])
         XCTAssertEqual(rootItems.count, 2)
         XCTAssertEqual(items.count, 1)
 
@@ -28,17 +28,17 @@ class LicensePlistHolderTests: XCTestCase {
         XCTAssertEqual(rootItems2["Title"], "name")
         XCTAssertEqual(rootItems2["File"], "com.mono0926.LicensePlist/name")
 
-        let item1 = items.first!.1
-        let item1_1 = item1["PreferenceSpecifiers"]!.first!
+        let item1 = try XCTUnwrap(items.first).1
+        let item1_1 = try XCTUnwrap(item1["PreferenceSpecifiers"]?.first)
         XCTAssertEqual(item1_1["Type"], "PSGroupSpecifier")
         XCTAssertEqual(item1_1["FooterText"], "\'<body>")
     }
-    func testLoad_allToRoot() {
+    func testLoad_allToRoot() throws {
         let pods = CocoaPods(name: "name", nameSpecified: nil, version: nil)
         let podsLicense = CocoaPodsLicense(library: pods, body: "'<body>")
         let result = LicensePlistHolder.loadAllToRoot(licenses: [podsLicense])
         let (root, items) = result.deserialized()
-        let rootItems = root["PreferenceSpecifiers"]!
+        let rootItems = try XCTUnwrap(root["PreferenceSpecifiers"])
         XCTAssertEqual(rootItems.count, 1)
         XCTAssertEqual(items.count, 0)
 
@@ -47,7 +47,7 @@ class LicensePlistHolderTests: XCTestCase {
         XCTAssertEqual(rootItems1["Title"], "name")
         XCTAssertEqual(rootItems1["FooterText"], "'<body>")
     }
-    func testLoad_splitByHorizontalLine() {
+    func testLoad_splitByHorizontalLine() throws {
         let pods = CocoaPods(name: "name", nameSpecified: nil, version: nil)
         let firstPart = "1\n2\n\n3\n---"
         let secondPart = "a"
@@ -57,8 +57,8 @@ class LicensePlistHolderTests: XCTestCase {
         let result = LicensePlistHolder.load(licenses: [podsLicense], options: Options.empty)
         let (_, items) = result.deserialized()
 
-        let item1 = items.first!.1
-        let groupArray = item1["PreferenceSpecifiers"]!
+        let item1 = items.first?.1
+        let groupArray = try XCTUnwrap(item1?["PreferenceSpecifiers"])
         XCTAssertEqual(groupArray.count, 5)
         let item1_0 = groupArray[0]
         XCTAssertEqual(item1_0["Type"], "PSGroupSpecifier")

--- a/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
+++ b/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
@@ -31,15 +31,15 @@ class PlistInfoTests: XCTestCase {
                                                  excludes: ["exclude"],
                                                  renames: ["Himotoki": "Himotoki2"]))
 
-    func testLoadCocoaPodsLicense() {
+    func testLoadCocoaPodsLicense() throws {
         var target = PlistInfo(options: options)
         XCTAssertNil(target.cocoaPodsLicenses)
         let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Tests/LicensePlistTests/Resources/acknowledgements.plist"
-        let content = try! String(contentsOf: URL(string: path)!)
+        let content = try String(contentsOf: XCTUnwrap(URL(string: path)))
         target.loadCocoaPodsLicense(acknowledgements: [content])
-        let licenses = target.cocoaPodsLicenses!
+        let licenses = try XCTUnwrap(target.cocoaPodsLicenses)
         XCTAssertEqual(licenses.count, 11)
-        let licenseFirst = licenses.first!
+        let licenseFirst = try XCTUnwrap(licenses.first)
         XCTAssertEqual(licenseFirst.library, CocoaPods(name: "Firebase", nameSpecified: nil, version: nil))
         XCTAssertEqual(licenseFirst.body, "Copyright 2017 Google")
     }
@@ -48,14 +48,14 @@ class PlistInfoTests: XCTestCase {
         var target = PlistInfo(options: options)
         XCTAssertNil(target.cocoaPodsLicenses)
         target.loadCocoaPodsLicense(acknowledgements: [])
-        XCTAssertEqual(target.cocoaPodsLicenses!, [])
+        XCTAssertEqual(target.cocoaPodsLicenses, [])
     }
 
-    func testLoadGitHubLibraries() {
+    func testLoadGitHubLibraries() throws {
         var target = PlistInfo(options: options)
         XCTAssertNil(target.githubLibraries)
         target.loadGitHubLibraries(file: .carthage(content: "github \"ikesyo/Himotoki\" \"3.0.1\""))
-        let libraries = target.githubLibraries!
+        let libraries = try XCTUnwrap(target.githubLibraries)
         XCTAssertEqual(libraries.count, 2)
         let lib1 = libraries[0]
         XCTAssertEqual(lib1, GitHub(name: "facebook-ios-sdk", nameSpecified: nil, owner: "facebook", version: "sdk-version-4.21.0"))
@@ -63,11 +63,11 @@ class PlistInfoTests: XCTestCase {
         XCTAssertEqual(lib2, GitHub(name: "Himotoki", nameSpecified: "Himotoki2", owner: "ikesyo", version: "3.0.1"))
     }
 
-    func testLoadGitHubLibraries_empty() {
+    func testLoadGitHubLibraries_empty() throws {
         var target = PlistInfo(options: options)
         XCTAssertNil(target.githubLibraries)
         target.loadGitHubLibraries(file: .carthage(content: nil))
-        let libraries = target.githubLibraries!
+        let libraries = try XCTUnwrap(target.githubLibraries)
         XCTAssertEqual(libraries.count, 1)
         let lib1 = libraries[0]
         XCTAssertEqual(lib1, GitHub(name: "facebook-ios-sdk", nameSpecified: nil, owner: "facebook", version: "sdk-version-4.21.0"))
@@ -88,22 +88,23 @@ class PlistInfoTests: XCTestCase {
         XCTAssertNotNil(target.summaryPath)
     }
 
-    func testDownloadGitHubLicenses() {
+    func testDownloadGitHubLicenses() throws {
         var target = PlistInfo(options: options)
         let github = GitHub(name: "LicensePlist", nameSpecified: nil, owner: "mono0926", version: nil)
         target.githubLibraries = [github]
 
         XCTAssertNil(target.githubLicenses)
         target.downloadGitHubLicenses()
-        XCTAssertEqual(target.githubLicenses!.count, 1)
-        let license = target.githubLicenses!.first!
+        let licenses = try XCTUnwrap(target.githubLicenses)
+        XCTAssertEqual(licenses.count, 1)
+        let license = licenses.first
 
-        XCTAssertEqual(license.library, github)
-        XCTAssertNotNil(license.body)
-        XCTAssertNotNil(license.githubResponse)
+        XCTAssertEqual(license?.library, github)
+        XCTAssertNotNil(license?.body)
+        XCTAssertNotNil(license?.githubResponse)
     }
 
-    func testCollectLicenseInfos() {
+    func testCollectLicenseInfos() throws {
         var target = PlistInfo(options: options)
         let github = GitHub(name: "LicensePlist", nameSpecified: nil, owner: "mono0926", version: nil)
         let githubLicense = GitHubLicense(library: github,
@@ -121,10 +122,10 @@ class PlistInfoTests: XCTestCase {
 
         XCTAssertNil(target.licenses)
         target.collectLicenseInfos()
-        let licenses = target.licenses!
+        let licenses = try XCTUnwrap(target.licenses)
         XCTAssertEqual(licenses.count, 2)
-        let license = licenses.last!
-        XCTAssertEqual(license.name, "LicensePlist")
+        let license = licenses.last
+        XCTAssertEqual(license?.name, "LicensePlist")
     }
 
     // MEMO: No result assertions

--- a/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
+++ b/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class SwiftPackageManagerTests: XCTestCase {
 
-    func testDecoding() {
+    func testDecoding() throws {
         let jsonString = """
             {
               "package": "APIKit",
@@ -24,8 +24,8 @@ class SwiftPackageManagerTests: XCTestCase {
             }
         """
 
-        let data = jsonString.data(using: .utf8)!
-        let package = try! JSONDecoder().decode(SwiftPackage.self, from: data)
+        let data = try XCTUnwrap(jsonString.data(using: .utf8))
+        let package = try JSONDecoder().decode(SwiftPackage.self, from: data)
 
         XCTAssertEqual(package.package, "APIKit")
         XCTAssertEqual(package.repositoryURL, "https://github.com/ishkawa/APIKit.git")
@@ -33,7 +33,7 @@ class SwiftPackageManagerTests: XCTestCase {
         XCTAssertEqual(package.state.version, "4.1.0")
     }
 
-    func testDecodingOfURLWithDots() {
+    func testDecodingOfURLWithDots() throws {
         let jsonString = """
             {
               "package": "R.swift.Library",
@@ -46,8 +46,8 @@ class SwiftPackageManagerTests: XCTestCase {
             }
         """
 
-        let data = jsonString.data(using: .utf8)!
-        let package = try! JSONDecoder().decode(SwiftPackage.self, from: data)
+        let data = try XCTUnwrap(jsonString.data(using: .utf8))
+        let package = try JSONDecoder().decode(SwiftPackage.self, from: data)
 
         XCTAssertEqual(package.package, "R.swift.Library")
         XCTAssertEqual(package.repositoryURL, "https://github.com/mac-cain13/R.swift.Library")
@@ -55,7 +55,7 @@ class SwiftPackageManagerTests: XCTestCase {
         XCTAssertEqual(package.state.version, nil)
     }
 
-    func testDecodingOptionalVersion() {
+    func testDecodingOptionalVersion() throws {
         let jsonString = """
             {
               "package": "APIKit",
@@ -68,8 +68,8 @@ class SwiftPackageManagerTests: XCTestCase {
             }
         """
 
-        let data = jsonString.data(using: .utf8)!
-        let package = try! JSONDecoder().decode(SwiftPackage.self, from: data)
+        let data = try XCTUnwrap(jsonString.data(using: .utf8))
+        let package = try JSONDecoder().decode(SwiftPackage.self, from: data)
 
         XCTAssertEqual(package.package, "APIKit")
         XCTAssertEqual(package.repositoryURL, "https://github.com/ishkawa/APIKit.git")
@@ -141,20 +141,20 @@ class SwiftPackageManagerTests: XCTestCase {
         XCTAssertNil(result)
     }
 
-    func testParse() {
+    func testParse() throws {
         let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Package.resolved"
         // let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Tests/LicensePlistTests/Resources/Package.resolved"
-        let content = try! String(contentsOf: URL(string: path)!)
+        let content = try String(contentsOf: XCTUnwrap(URL(string: path)))
         let packages = SwiftPackage.loadPackages(content)
 
         XCTAssertFalse(packages.isEmpty)
         XCTAssertEqual(packages.count, 7)
 
-        let packageFirst = packages.first!
+        let packageFirst = try XCTUnwrap(packages.first)
         XCTAssertEqual(packageFirst, SwiftPackage(package: "APIKit",
                                                   repositoryURL: "https://github.com/ishkawa/APIKit.git",
                                                   state: SwiftPackage.State(branch: nil, revision: "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4", version: "5.2.0")))
-        let packageLast = packages.last!
+        let packageLast = try XCTUnwrap(packages.last)
         XCTAssertEqual(packageLast, SwiftPackage(package: "Yaml",
                                                  repositoryURL: "https://github.com/behrang/YamlSwift.git",
                                                  state: SwiftPackage.State(branch: nil, revision: "287f5cab7da0d92eb947b5fd8151b203ae04a9a3", version: "3.4.4")))

--- a/Tests/LicensePlistTests/Entity/VersionInfoTests.swift
+++ b/Tests/LicensePlistTests/Entity/VersionInfoTests.swift
@@ -9,9 +9,9 @@ class VersionInfoTests: XCTestCase {
         XCTAssertTrue(results.dictionary.isEmpty)
     }
 
-    func testInit() {
+    func testInit() throws {
         let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Tests/LicensePlistTests/Resources/Manifest.lock"
-        let content = try! String(contentsOf: URL(string: path)!)
+        let content = try String(contentsOf: XCTUnwrap(URL(string: path)))
         let results = VersionInfo(podsManifest: content)
         XCTAssertFalse(results.dictionary.isEmpty)
         XCTAssertEqual(results.dictionary.count, 30)

--- a/Tests/LicensePlistTests/Extension/URL.extensionTests.swift
+++ b/Tests/LicensePlistTests/Extension/URL.extensionTests.swift
@@ -4,12 +4,12 @@ import APIKit
 @testable import LicensePlistCore
 
 class URLExtensionTests: XCTestCase {
-    func testDownloadContent() {
-        let url = URL(string: "https://raw.githubusercontent.com/mono0926/LicensePlist/master/LICENSE")!
-        XCTAssertTrue(try! url.lp.download().resultSync().get().hasPrefix("MIT License"))
+    func testDownloadContent() throws {
+        let url = try XCTUnwrap(URL(string: "https://raw.githubusercontent.com/mono0926/LicensePlist/master/LICENSE"))
+        XCTAssertTrue(try url.lp.download().resultSync().get().hasPrefix("MIT License"))
     }
     func testFileURL() throws {
-        let url = URL(string: "/github.com/mono0926/LicensePlist")!
+        let url = try XCTUnwrap(URL(string: "/github.com/mono0926/LicensePlist"))
         XCTAssertEqual(url.lp.fileURL.absoluteString, "file:///github.com/mono0926/LicensePlist")
     }
 }

--- a/Tests/LicensePlistTests/GitHubClient/RepoRequestsTests.swift
+++ b/Tests/LicensePlistTests/GitHubClient/RepoRequestsTests.swift
@@ -25,19 +25,19 @@ class RepoRequestsTests: XCTestCase {
         case .success(let response):
             XCTAssertEqual(
                 response.parent?.htmlUrl,
-                URL(string: "https://github.com/adjust/ios_sdk")!)
+                URL(string: "https://github.com/adjust/ios_sdk"))
         case .failure(let error):
             XCTFail(String(describing: error))
         }
     }
-    func testLicense_multiple() {
+    func testLicense_multiple() throws {
         let request1 = RepoRequests.License(owner: "mono0926", repo: "NativePopup")
         let request2 = RepoRequests.License(owner: "ReactiveX", repo: "RxSwift")
         let o1 = Session.shared.lp.send(request1)
         let o2 = Session.shared.lp.send(request2)
         let queue = OperationQueue()
         queue.addOperations([o1, o2], waitUntilFinished: true)
-        let result = [try! o1.result!.get(), try! o2.result!.get()]
+        let result = try [XCTUnwrap(o1.result).get(), XCTUnwrap(o2.result).get()]
         XCTAssertEqual(result.count, 2)
         XCTAssertTrue(result[0].contentDecoded.hasPrefix("MIT License"))
         XCTAssertTrue(result[1].contentDecoded.hasPrefix("**The MIT License**"))

--- a/Tests/LicensePlistTests/GitHubClient/SearchRequestsTests.swift
+++ b/Tests/LicensePlistTests/GitHubClient/SearchRequestsTests.swift
@@ -8,13 +8,13 @@ class SearchRequestsTests: XCTestCase {
         super.setUp()
         TestUtil.setGitHubToken()
     }
-    func testRepositories() {
+    func testRepositories() throws {
         let request = SearchRequests.Repositories(query: "NativePopup")
         let result = Session.shared.lp.sendSync(request)
         switch result {
         case .success(let response):
-            let item = response.items.first!
-            XCTAssertEqual(item.htmlUrl, URL(string: "https://github.com/mono0926/NativePopup")!)
+            let item = try XCTUnwrap(response.items.first)
+            XCTAssertEqual(item.htmlUrl, URL(string: "https://github.com/mono0926/NativePopup"))
             XCTAssertEqual(item.owner.login, "mono0926")
             XCTAssertEqual(item.name, "NativePopup")
         case .failure(let error):

--- a/Tests/LicensePlistTests/ResultOperationTests.swift
+++ b/Tests/LicensePlistTests/ResultOperationTests.swift
@@ -5,10 +5,10 @@ import APIKit
 
 class ResultOperatoinTests: XCTestCase {
 
-    func testBlocking() {
+    func testBlocking() throws {
         let operation = ResultOperation<String, NSError> { _ in
             return Result.success("hello")
         }
-        XCTAssertEqual(try! operation.resultSync().get(), "hello")
+        XCTAssertEqual(try operation.resultSync().get(), "hello")
     }
 }


### PR DESCRIPTION
Safely unwraps Optionals so the unit tests don't crash the entire test run when an unexpected nil is encountered