### PR TITLE
Add `swift-package-path` as a custom long name to the optional argument `packagePath`

### DIFF
--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -27,7 +27,7 @@ struct LicensePlist: ParsableCommand {
 	@Option(name: .long, completion: .directory)
 	var podsPath = Consts.podsDirectoryName
 
-	@Option(name: .long, completion: .file())
+	@Option(name: [.long, .customLong("swift-package-path")], completion: .file())
 	var packagePath = Consts.packageName
 
 	@Option(name: .long, completion: .file())


### PR DESCRIPTION
Hello, @mono0926 
Thank you for this awesome library!

I tried to use this LicensePlist via the Swift Package Manager by doing something like `swift run license-plist`.
However, both `swift run` and `license-plist` had an option with the same name, `package-path`, which caused problems with execution.
So, I added `swift-package-path` as an alias to that in the `license-plist` to avoid this problem.

----------

`swift run` から `license-plist` を実行する際に、両者にある同名のオプション `package-path` の衝突による実行の不具合を避けるため、`license-plist` の `package-path` に別名 `swift-package-path` を追加することを提案します。