### PR TITLE
Support for multiple Package.swift

### DIFF
--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -27,7 +27,7 @@ struct LicensePlist: ParsableCommand {
 	@Option(name: .long, completion: .directory)
 	var podsPath = Consts.podsDirectoryName
 
-	@Option(name: [.customLong("package-path"), .customLong("swift-package-path"), .long, .customLong("swift-package-paths")], completion: .file())
+	@Option(name: [.customLong("package-path"), .customLong("swift-package-path"), .long, .customLong("swift-package-paths")], parsing: .upToNextOption, completion: .file())
 	var packagePaths = [Consts.packageName]
 
 	@Option(name: .long, completion: .file())

--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -27,8 +27,8 @@ struct LicensePlist: ParsableCommand {
 	@Option(name: .long, completion: .directory)
 	var podsPath = Consts.podsDirectoryName
 
-	@Option(name: [.long, .customLong("swift-package-path")], completion: .file())
-	var packagePath = Consts.packageName
+	@Option(name: [.customLong("package-path"), .customLong("swift-package-path"), .long, .customLong("swift-package-paths")], completion: .file())
+	var packagePaths = [Consts.packageName]
 
 	@Option(name: .long, completion: .file())
 	var xcodeprojPath = "*.xcodeproj"
@@ -79,7 +79,7 @@ struct LicensePlist: ParsableCommand {
 									 cartfilePath: URL(fileURLWithPath: cartfilePath),
 									 mintfilePath: URL(fileURLWithPath: mintfilePath),
 									 podsPath: URL(fileURLWithPath: podsPath),
-									 packagePath: URL(fileURLWithPath: packagePath),
+									 packagePaths: packagePaths.map { URL(fileURLWithPath: $0) },
 									 xcodeprojPath: URL(fileURLWithPath: xcodeprojPath),
 									 prefix: prefix,
 									 gitHubToken: githubToken ?? ProcessInfo.processInfo.environment[Self.githubTokenEnv],

--- a/Sources/LicensePlistCore/Entity/Options.swift
+++ b/Sources/LicensePlistCore/Entity/Options.swift
@@ -5,7 +5,7 @@ public struct Options {
     public let cartfilePath: URL
     public let mintfilePath: URL
     public let podsPath: URL
-    public let packagePath: URL
+    public let packagePaths: [URL]
     public let xcodeprojPath: URL
     public let prefix: String
     public let gitHubToken: String?
@@ -17,7 +17,7 @@ public struct Options {
                                       cartfilePath: URL(fileURLWithPath: ""),
                                       mintfilePath: URL(fileURLWithPath: ""),
                                       podsPath: URL(fileURLWithPath: ""),
-                                      packagePath: URL(fileURLWithPath: ""),
+                                      packagePaths: [],
                                       xcodeprojPath: URL(fileURLWithPath: ""),
                                       prefix: Consts.prefix,
                                       gitHubToken: nil,
@@ -29,7 +29,7 @@ public struct Options {
                 cartfilePath: URL,
                 mintfilePath: URL,
                 podsPath: URL,
-                packagePath: URL,
+                packagePaths: [URL],
                 xcodeprojPath: URL,
                 prefix: String,
                 gitHubToken: String?,
@@ -40,7 +40,7 @@ public struct Options {
         self.cartfilePath = cartfilePath
         self.mintfilePath = mintfilePath
         self.podsPath = podsPath
-        self.packagePath = packagePath
+        self.packagePaths = packagePaths
         self.xcodeprojPath = xcodeprojPath
         self.prefix = prefix
         self.gitHubToken = gitHubToken

--- a/Sources/LicensePlistCore/Entity/PlistInfo.swift
+++ b/Sources/LicensePlistCore/Entity/PlistInfo.swift
@@ -45,10 +45,7 @@ struct PlistInfo {
     mutating func loadSwiftPackageLibraries(packageFiles: [String]) {
         Log.info("Swift Package Manager License collect start")
 
-        var packages: [SwiftPackage] = []
-        packageFiles.forEach { packageFile in
-            packages += SwiftPackage.loadPackages(packageFile)
-        }
+        let packages = packageFiles.flatMap { SwiftPackage.loadPackages($0) }
         let packagesAsGithubLibraries = packages.compactMap { $0.toGitHub(renames: options.config.renames) }.sorted()
 
         githubLibraries = (githubLibraries ?? []) + options.config.apply(githubs: packagesAsGithubLibraries)

--- a/Sources/LicensePlistCore/Entity/PlistInfo.swift
+++ b/Sources/LicensePlistCore/Entity/PlistInfo.swift
@@ -42,10 +42,13 @@ struct PlistInfo {
         githubLibraries = ((githubLibraries ?? []) + options.config.apply(githubs: githubs)).sorted()
     }
 
-    mutating func loadSwiftPackageLibraries(packageFile: String?) {
+    mutating func loadSwiftPackageLibraries(packageFiles: [String]) {
         Log.info("Swift Package Manager License collect start")
 
-        let packages = SwiftPackage.loadPackages(packageFile ?? "")
+        var packages: [SwiftPackage] = []
+        packageFiles.forEach { packageFile in
+            packages += SwiftPackage.loadPackages(packageFile)
+        }
         let packagesAsGithubLibraries = packages.compactMap { $0.toGitHub(renames: options.config.renames) }.sorted()
 
         githubLibraries = (githubLibraries ?? []) + options.config.apply(githubs: packagesAsGithubLibraries)

--- a/Sources/LicensePlistCore/LicensePlist.swift
+++ b/Sources/LicensePlistCore/LicensePlist.swift
@@ -18,7 +18,6 @@ public final class LicensePlist {
                 try SwiftPackageFileReader(path: packagePath).read()
             }
             let xcodeProjectFileReadResult = try XcodeProjectFileReader(path: options.xcodeprojPath).read()
-            
             info.loadSwiftPackageLibraries(
                 packageFiles: swiftPackageFileReadResults.isEmpty
                     ? [xcodeProjectFileReadResult ?? ""]

--- a/Sources/LicensePlistCore/LicensePlist.swift
+++ b/Sources/LicensePlistCore/LicensePlist.swift
@@ -14,9 +14,16 @@ public final class LicensePlist {
         info.loadGitHubLibraries(file: readMintfile(path: options.mintfilePath))
 
         do {
-            let swiftPackageFileReadResult = try SwiftPackageFileReader(path: options.packagePath).read()
+            let swiftPackageFileReadResults = try options.packagePaths.compactMap { packagePath in
+                try SwiftPackageFileReader(path: packagePath).read()
+            }
             let xcodeProjectFileReadResult = try XcodeProjectFileReader(path: options.xcodeprojPath).read()
-            info.loadSwiftPackageLibraries(packageFile: swiftPackageFileReadResult ?? xcodeProjectFileReadResult)
+            
+            info.loadSwiftPackageLibraries(
+                packageFiles: swiftPackageFileReadResults.isEmpty
+                    ? [xcodeProjectFileReadResult ?? ""]
+                    : swiftPackageFileReadResults
+            )
         } catch {
             fatalError(error.localizedDescription)
         }

--- a/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
+++ b/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
@@ -13,7 +13,7 @@ class PlistInfoTests: XCTestCase {
                                   cartfilePath: URL(fileURLWithPath: "test_result_dir"),
                                   mintfilePath: URL(fileURLWithPath: "test_result_dir"),
                                   podsPath: URL(fileURLWithPath: "test_result_dir"),
-                                  packagePath: URL(fileURLWithPath: "test_result_dir"),
+                                  packagePaths: [URL(fileURLWithPath: "test_result_dir")],
                                   xcodeprojPath: URL(fileURLWithPath: "test_result_dir"),
                                   prefix: Consts.prefix,
                                   gitHubToken: nil,


### PR DESCRIPTION
Assuming we have a project with modules split by Swift Package, they may have more than one Package.swift.
In this case, it is very useful to be able to specify multiple Package.swift as follows.

```
license-plist --package-paths /path/to/package1/Package.swift /path/to/package2/Package.swift
```

The old `--package-path` (alias `--swift-package-path`) has been changed to `--package-paths` , but the old name has been retained as an alias to avoid destructive changes when used from the CLI.