### PR TITLE
Universal Binary distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ TEMPORARY_FOLDER=./tmp_portable_licenseplist
 build:
 	swift build --disable-sandbox -c release
 
+build_portable:
+	swift build --disable-sandbox -c release --arch x86_64 --arch arm64
+
 test:
 	swift test
 
@@ -21,9 +24,9 @@ install: build
 	mkdir -p "$(PREFIX)/bin"
 	cp -f ".build/release/license-plist" "$(PREFIX)/bin/license-plist"
 
-portable_zip: build
+portable_zip: build_portable
 	mkdir -p "$(TEMPORARY_FOLDER)"
-	cp -f ".build/release/license-plist" "$(TEMPORARY_FOLDER)/license-plist"
+	cp -f ".build/apple/Products/Release/license-plist" "$(TEMPORARY_FOLDER)/license-plist"
 	cp -f "LICENSE" "$(TEMPORARY_FOLDER)"
 	(cd $(TEMPORARY_FOLDER); zip -r - LICENSE license-plist) > "./portable_licenseplist.zip"
 	rm -r "$(TEMPORARY_FOLDER)"


### PR DESCRIPTION
## Description

Currently, It is distributed on GitHub release page and CocoaPods  as a x86_64 format executable.

```sh
$ curl -fsSL "https://github.com/mono0926/LicensePlist/releases/download/3.13.0/portable_licenseplist.zip" | bsdtar xf - -C .
$ lipo -archs license-plist
x86_64
```

This PR changes the distributed executable to Universal Binary (x86_64 + arm64).

Resolve #148

## Test

### Before

```sh
$ swift build --version
Swift Package Manager - Swift 5.4.0

$ make clean && make portable_zip > /dev/null
swift package clean
  adding: LICENSE (deflated 41%)
  adding: license-plist (deflated 73%)

$ unzip portable_licenseplist.zip license-plist && lipo -archs license-plist
Archive:  portable_licenseplist.zip
  inflating: license-plist
x86_64
```

### After

```sh
$ swift build --version
Swift Package Manager - Swift 5.4.0

$ make clean && make portable_zip > /dev/null
swift package clean
  adding: LICENSE (deflated 41%)
  adding: license-plist (deflated 73%)

$ unzip portable_licenseplist.zip license-plist && lipo -archs license-plist
Archive:  portable_licenseplist.zip
  inflating: license-plist
x86_64 arm64

```

## Reference

- [Building Swift Packages as a Universal Binary
](https://liamnichols.eu/2020/08/01/building-swift-packages-as-a-universal-binary.html)