### PR TITLE
Adds --xcworkspace-path option and "file parser"

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,23 @@ You can see options by `license-plist --help`.
 #### `--package-path`
 
 - Default: `Package.swift`
-- `LicensePlist` tries to find `YourProjectName.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` and `YourProjectName.xcworkspace/xcshareddata/swiftpm/Package.resolved`, then uses new one. If you make anothor workspace in custom directory,  you can use `--package-path PathToYourCustomWorkspace/CustomWorkspaceName.xcworkspace/xcshareddata/swiftpm/Package.swift` inside your `Run script`.
+- `LicensePlist` tries to find `YourProjectName.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` and `YourProjectName.xcworkspace/xcshareddata/swiftpm/Package.resolved`, then uses new one.
+
+### `--xcodeproj-path`
+
+- Default: `"*.xcodeproj"`
+- By specifiying the path to the `.xcodeproj` `LicensePlist` will attempt to load the `Package.resolved` from that Xcode project. If you specify `somedir/*.xcodeproj` then `LicensePlist` will load from the first `xcodeproj` it finds in `somedir`.
+
+#### `--xcworkspace-path`
+
+- Default: `"*.xcworkspace"`
+- By specifying the path to the `.xcworkspace` `LicensePlist` will load the `Package.resolved` from that Xcode workspace. If you specify `somedir/*.xcworkspace` then `LicensePlist` will load from the first `xcworkspace` it finds in `somedir`.
+- `--xcworkspace-path` supersedes any provided `--xcodeproj-path`.
 
 #### `--output-path`
 
 - Default: `com.mono0926.LicensePlist.Output`
 - Recommended: `--output-path YOUR_PRODUCT_DIR/Settings.bundle`
-
 
 #### `--github-token`
 

--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -30,6 +30,9 @@ struct LicensePlist: ParsableCommand {
 	@Option(name: [.customLong("package-path"), .customLong("swift-package-path"), .long, .customLong("swift-package-paths")], parsing: .upToNextOption, completion: .file())
 	var packagePaths = [Consts.packageName]
 
+    @Option(name: .long, completion: .file())
+    var xcworkspacePath = "*.xcworkspace"
+
 	@Option(name: .long, completion: .file())
 	var xcodeprojPath = "*.xcodeproj"
 
@@ -80,6 +83,7 @@ struct LicensePlist: ParsableCommand {
 									 mintfilePath: URL(fileURLWithPath: mintfilePath),
 									 podsPath: URL(fileURLWithPath: podsPath),
 									 packagePaths: packagePaths.map { URL(fileURLWithPath: $0) },
+                                     xcworkspacePath: URL(fileURLWithPath: xcworkspacePath),
 									 xcodeprojPath: URL(fileURLWithPath: xcodeprojPath),
 									 prefix: prefix,
 									 gitHubToken: githubToken ?? ProcessInfo.processInfo.environment[Self.githubTokenEnv],

--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -11,88 +11,88 @@ private func loadConfig(configPath: URL) -> Config {
 }
 
 extension CompletionKind {
-	static var empty: CompletionKind {
-		return .custom { _ in return [] }
-	}
+    static var empty: CompletionKind {
+        return .custom { _ in return [] }
+    }
 }
 
 // Typename used for usage in help command
 struct LicensePlist: ParsableCommand {
-	@Option(name: .long, completion: .file())
-	var cartfilePath = Consts.cartfileName
+    @Option(name: .long, completion: .file())
+    var cartfilePath = Consts.cartfileName
 
-	@Option(name: .long, completion: .file())
-	var mintfilePath = Consts.mintfileName
+    @Option(name: .long, completion: .file())
+    var mintfilePath = Consts.mintfileName
 
-	@Option(name: .long, completion: .directory)
-	var podsPath = Consts.podsDirectoryName
+    @Option(name: .long, completion: .directory)
+    var podsPath = Consts.podsDirectoryName
 
-	@Option(name: [.customLong("package-path"), .customLong("swift-package-path"), .long, .customLong("swift-package-paths")], parsing: .upToNextOption, completion: .file())
-	var packagePaths = [Consts.packageName]
+    @Option(name: [.customLong("package-path"), .customLong("swift-package-path"), .long, .customLong("swift-package-paths")], parsing: .upToNextOption, completion: .file())
+    var packagePaths = [Consts.packageName]
 
     @Option(name: .long, completion: .file())
     var xcworkspacePath = "*.xcworkspace"
 
-	@Option(name: .long, completion: .file())
-	var xcodeprojPath = "*.xcodeproj"
+    @Option(name: .long, completion: .file())
+    var xcodeprojPath = "*.xcodeproj"
 
-	@Option(name: .long, completion: .file())
-	var outputPath = Consts.outputPath
+    @Option(name: .long, completion: .file())
+    var outputPath = Consts.outputPath
 
-	static let githubTokenEnv = "LICENSE_PLIST_GITHUB_TOKEN"
-	@Option(name: .long, help: "You can also pass the token via the '\(Self.githubTokenEnv)' environment variable.", completion: .empty)
-	var githubToken: String?
+    static let githubTokenEnv = "LICENSE_PLIST_GITHUB_TOKEN"
+    @Option(name: .long, help: "You can also pass the token via the '\(Self.githubTokenEnv)' environment variable.", completion: .empty)
+    var githubToken: String?
 
-	@Option(name: .long, completion: .file())
-	var configPath = Consts.configPath
+    @Option(name: .long, completion: .file())
+    var configPath = Consts.configPath
 
-	@Option(name: .long, completion: .empty)
-	var prefix = Consts.prefix
+    @Option(name: .long, completion: .empty)
+    var prefix = Consts.prefix
 
-	@Option(name: .long, completion: .file())
-	var htmlPath: String?
+    @Option(name: .long, completion: .file())
+    var htmlPath: String?
 
-	@Option(name: .long, completion: .file())
-	var markdownPath: String?
+    @Option(name: .long, completion: .file())
+    var markdownPath: String?
 
-	@Flag(name: .long)
-	var force = false
+    @Flag(name: .long)
+    var force = false
 
-	@Flag(name: .long)
-	var addVersionNumbers = false
+    @Flag(name: .long)
+    var addVersionNumbers = false
 
-	@Flag(name: .long)
-	var suppressOpeningDirectory = false
+    @Flag(name: .long)
+    var suppressOpeningDirectory = false
 
-	@Flag(name: .long)
-	var singlePage = false
+    @Flag(name: .long)
+    var singlePage = false
 
-	@Flag(name: .long)
-	var failIfMissingLicense = false
+    @Flag(name: .long)
+    var failIfMissingLicense = false
 
-	func run() throws {
-		Logger.configure()
-		var config = loadConfig(configPath: URL(fileURLWithPath: configPath))
-		config.force = force
-		config.addVersionNumbers = addVersionNumbers
-		config.suppressOpeningDirectory = suppressOpeningDirectory
-		config.singlePage = singlePage
-		config.failIfMissingLicense = failIfMissingLicense
-		let options = Options(outputPath: URL(fileURLWithPath: outputPath),
-									 cartfilePath: URL(fileURLWithPath: cartfilePath),
-									 mintfilePath: URL(fileURLWithPath: mintfilePath),
-									 podsPath: URL(fileURLWithPath: podsPath),
-									 packagePaths: packagePaths.map { URL(fileURLWithPath: $0) },
-                                     xcworkspacePath: URL(fileURLWithPath: xcworkspacePath),
-									 xcodeprojPath: URL(fileURLWithPath: xcodeprojPath),
-									 prefix: prefix,
-									 gitHubToken: githubToken ?? ProcessInfo.processInfo.environment[Self.githubTokenEnv],
-									 htmlPath: htmlPath.map { return URL(fileURLWithPath: $0) },
-									 markdownPath: markdownPath.map { return URL(fileURLWithPath: $0) },
-									 config: config)
-		let tool = LicensePlistCore.LicensePlist()
-		tool.process(options: options)
-	}
+    func run() throws {
+        Logger.configure()
+        var config = loadConfig(configPath: URL(fileURLWithPath: configPath))
+        config.force = force
+        config.addVersionNumbers = addVersionNumbers
+        config.suppressOpeningDirectory = suppressOpeningDirectory
+        config.singlePage = singlePage
+        config.failIfMissingLicense = failIfMissingLicense
+        let options = Options(outputPath: URL(fileURLWithPath: outputPath),
+                              cartfilePath: URL(fileURLWithPath: cartfilePath),
+                              mintfilePath: URL(fileURLWithPath: mintfilePath),
+                              podsPath: URL(fileURLWithPath: podsPath),
+                              packagePaths: packagePaths.map { URL(fileURLWithPath: $0) },
+                              xcworkspacePath: URL(fileURLWithPath: xcworkspacePath),
+                              xcodeprojPath: URL(fileURLWithPath: xcodeprojPath),
+                              prefix: prefix,
+                              gitHubToken: githubToken ?? ProcessInfo.processInfo.environment[Self.githubTokenEnv],
+                              htmlPath: htmlPath.map { return URL(fileURLWithPath: $0) },
+                              markdownPath: markdownPath.map { return URL(fileURLWithPath: $0) },
+                              config: config)
+        let tool = LicensePlistCore.LicensePlist()
+        tool.process(options: options)
+    }
 }
 
 LicensePlist.main()

--- a/Sources/LicensePlistCore/Consts.swift
+++ b/Sources/LicensePlistCore/Consts.swift
@@ -5,6 +5,7 @@ public struct Consts {
     public static let mintfileName = "Mintfile"
     public static let podsDirectoryName = "Pods"
     public static let packageName = "Package.swift"
+    public static let xcworkspaceExtension = "xcworkspace"
     public static let xcodeprojExtension = "xcodeproj"
     public static let prefix = "com.mono0926.LicensePlist"
     public static let outputPath = "\(prefix).Output"

--- a/Sources/LicensePlistCore/Entity/FileReader/XcodeWorkspaceFileReader.swift
+++ b/Sources/LicensePlistCore/Entity/FileReader/XcodeWorkspaceFileReader.swift
@@ -7,7 +7,7 @@ struct XcodeWorkspaceFileReader: FileReader {
 
     let path: URL
 
-    /// The path which specifies `"*.xcworkspace` file wrapper.
+    /// The path which specifies `"*.xcworkspace"` file wrapper.
     var workspacePath: URL? {
         if path.lastPathComponent.contains("*") {
             // find first "xcworkspace" in directory

--- a/Sources/LicensePlistCore/Entity/FileReader/XcodeWorkspaceFileReader.swift
+++ b/Sources/LicensePlistCore/Entity/FileReader/XcodeWorkspaceFileReader.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// An object that reads a xcodeproj file.
+struct XcodeWorkspaceFileReader: FileReader {
+
+    typealias ResultType = String?
+
+    let path: URL
+
+    /// The path which specifies `"*.xcworkspace` file wrapper.
+    var workspacePath: URL? {
+        if path.lastPathComponent.contains("*") {
+            // find first "xcworkspace" in directory
+            return path.deletingLastPathComponent().lp.listDir().first { $0.pathExtension == Consts.xcworkspaceExtension }
+        } else {
+            // use the specified path
+            return path
+        }
+    }
+
+    func read() throws -> String? {
+        guard let validatedPath = workspacePath else { return nil }
+
+        if validatedPath.pathExtension != Consts.xcworkspaceExtension {
+            return nil
+        }
+
+        let packageResolvedPath = validatedPath
+            .appendingPathComponent("xcshareddata")
+            .appendingPathComponent("swiftpm")
+            .appendingPathComponent("Package.resolved")
+
+        guard packageResolvedPath.lp.isExists else {
+            return nil
+        }
+
+        return try SwiftPackageFileReader(path: packageResolvedPath).read()
+    }
+
+}

--- a/Sources/LicensePlistCore/Entity/Options.swift
+++ b/Sources/LicensePlistCore/Entity/Options.swift
@@ -6,6 +6,7 @@ public struct Options {
     public let mintfilePath: URL
     public let podsPath: URL
     public let packagePaths: [URL]
+    public let xcworkspacePath: URL
     public let xcodeprojPath: URL
     public let prefix: String
     public let gitHubToken: String?
@@ -18,6 +19,7 @@ public struct Options {
                                       mintfilePath: URL(fileURLWithPath: ""),
                                       podsPath: URL(fileURLWithPath: ""),
                                       packagePaths: [],
+                                      xcworkspacePath: URL(fileURLWithPath: ""),
                                       xcodeprojPath: URL(fileURLWithPath: ""),
                                       prefix: Consts.prefix,
                                       gitHubToken: nil,
@@ -30,6 +32,7 @@ public struct Options {
                 mintfilePath: URL,
                 podsPath: URL,
                 packagePaths: [URL],
+                xcworkspacePath: URL,
                 xcodeprojPath: URL,
                 prefix: String,
                 gitHubToken: String?,
@@ -41,6 +44,7 @@ public struct Options {
         self.mintfilePath = mintfilePath
         self.podsPath = podsPath
         self.packagePaths = packagePaths
+        self.xcworkspacePath = xcworkspacePath
         self.xcodeprojPath = xcodeprojPath
         self.prefix = prefix
         self.gitHubToken = gitHubToken

--- a/Tests/LicensePlistTests/Entity/FileReader/XcodeWorkspaceFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/XcodeWorkspaceFileReaderTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import LicensePlistCore
+
+@available(OSX 10.11, *)
+class XcodeWorkspaceFileReaderTests: XCTestCase {
+
+    var workspaceFileURL: URL!
+    var wildcardFileURL: URL!
+
+    override func setUpWithError() throws {
+        workspaceFileURL = URL(fileURLWithPath: "\(TestUtil.testProjectsPath)/SwiftPackageManagerTestProject/SwiftPackageManagerTestProject.xcworkspace")
+        wildcardFileURL = URL(fileURLWithPath: "\(TestUtil.testProjectsPath)/SwiftPackageManagerTestProject/*")
+
+        print("fileURL: \(String(describing: workspaceFileURL))")
+        print("wildcardURL: \(String(describing: wildcardFileURL))")
+    }
+
+    override func tearDownWithError() throws {
+        workspaceFileURL = nil
+        wildcardFileURL = nil
+    }
+
+    func testProjectPathWhenSpecifiesCorrectFilePath() throws {
+        let fileReader = XcodeWorkspaceFileReader(path: workspaceFileURL)
+        XCTAssertEqual(fileReader.workspacePath, workspaceFileURL)
+    }
+
+    func testProjectPathWhenSpecifiesWildcard() throws {
+        let fileReader = XcodeWorkspaceFileReader(path: wildcardFileURL)
+        XCTAssertEqual(fileReader.workspacePath, workspaceFileURL)
+    }
+
+    func testReadNotNil() throws {
+        let fileReader = XcodeWorkspaceFileReader(path: workspaceFileURL)
+        XCTAssertNotNil(try fileReader.read())
+    }
+}

--- a/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
+++ b/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
@@ -14,6 +14,7 @@ class PlistInfoTests: XCTestCase {
                                   mintfilePath: URL(fileURLWithPath: "test_result_dir"),
                                   podsPath: URL(fileURLWithPath: "test_result_dir"),
                                   packagePaths: [URL(fileURLWithPath: "test_result_dir")],
+                                  xcworkspacePath: URL(fileURLWithPath: "test_result_dir"),
                                   xcodeprojPath: URL(fileURLWithPath: "test_result_dir"),
                                   prefix: Consts.prefix,
                                   gitHubToken: nil,


### PR DESCRIPTION
Prior to this change you could not specify to look in a specific `.xcworkspace` folder for the `Package.resolved` file.

This change introduces a new command line option (that takes precendence over `--xcodeproj-path`) to direct LicensePlist to look in a specific workspace for the `Package.resolved` file.

Resolves #165

Happy to alter this PR if it doesn't fit in. Let me know how I can improve it.