### PR TITLE
Update sample yaml config to use multi-line string literal and fix typo.

### DIFF
--- a/Tests/LicensePlistTests/Resources/license_plist.yml
+++ b/Tests/LicensePlistTests/Resources/license_plist.yml
@@ -5,7 +5,7 @@ github:
   - owner: mono0926
     name: LicensePlist
     version: 1.2.0
-  # Depricated(Will be removed at Version 2. Use above.)
+  # Deprecated (Will be removed at Version 2. Use above.)
   - mono0926/NativePopup
 
 # Specify libraries manually
@@ -13,32 +13,31 @@ manual:
   - source: https://webrtc.googlesource.com/src
     name: WebRTC
     version: M61
-    body: '
-    Copyright (c) 2011, The WebRTC project authors. All rights reserved.
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-  * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-  * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in
-    the documentation and/or other materials provided with the
-    distribution.
-  * Neither the name of Google nor the names of its contributors may
-    be used to endorse or promote products derived from this software
-    without specific prior written permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-'
+    body: |-
+      Copyright (c) 2011, The WebRTC project authors. All rights reserved.
+      Redistribution and use in source and binary forms, with or without
+      modification, are permitted provided that the following conditions are
+      met:
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above copyright
+          notice, this list of conditions and the following disclaimer in
+          the documentation and/or other materials provided with the
+          distribution.
+        * Neither the name of Google nor the names of its contributors may
+          be used to endorse or promote products derived from this software
+          without specific prior written permission.
+      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+      "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+      LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+      A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+      HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+      SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+      LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+      DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+      THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Specify license files manually
   - name: "Dummy License File"


### PR DESCRIPTION
License lines are squashed together with leading spaces when I use the `license_plist.yml` to specify manual licenses, presenting with [LicensePlistViewController](https://github.com/yhirano/LicensePlistViewController)

<img width="320" alt="Screenshot 2021-11-14 PM 11 38 40" src="https://user-images.githubusercontent.com/8158163/141688163-b92d3dfe-0ec4-4cfa-934b-071b5fa2b1f3.png">

YAML supports [multi-line string literal syntax](https://stackoverflow.com/questions/3790454/how-do-i-break-a-string-in-yaml-over-multiple-lines#21699210) that preserves line breaks, which looks neater.

<img width="320" alt="Screenshot 2021-11-14 PM 11 54 51" src="https://user-images.githubusercontent.com/8158163/141688360-b2c5f452-59e4-4418-8b2f-002144e2d932.png">

This PR updates `license_plist.yml` to use multi-line string literal syntax to describe manual licenses and fixes a typo.