### PR TITLE
Support `--version` option

### DIFF
--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -18,6 +18,8 @@ extension CompletionKind {
 
 // Typename used for usage in help command
 struct LicensePlist: ParsableCommand {
+    static let configuration = CommandConfiguration(version: Consts.version)
+
     @Option(name: .long, completion: .file())
     var cartfilePath = Consts.cartfileName
 


### PR DESCRIPTION
Close #172

Swift Argument Parser has a built-in support for the `--version` option.

- https://github.com/apple/swift-argument-parser/pull/102

I used this feature in my implementation.

## Confirmation

```sh
$ make build
$ .build/release/license-plist --version
3.16.0
```
