### PR TITLE
Add support for Swift Package Manager 5.6

### DIFF
--- a/Sources/LicensePlistCore/Entity/SwiftPackage.swift
+++ b/Sources/LicensePlistCore/Entity/SwiftPackage.swift
@@ -7,8 +7,15 @@
 
 import Foundation
 
-public struct SwiftPackage: Decodable, Equatable {
-    struct State: Decodable, Equatable {
+public struct SwiftPackage: Equatable {
+    let package: String
+    let repositoryURL: String
+    let revision: String?
+    let version: String?
+}
+
+struct SwiftPackageV1: Decodable {
+    struct State: Decodable {
         let branch: String?
         let revision: String?
         let version: String?
@@ -19,22 +26,48 @@ public struct SwiftPackage: Decodable, Equatable {
     let state: State
 }
 
-private struct ResolvedPackages: Decodable {
+struct ResolvedPackagesV1: Decodable {
     struct Pins: Decodable {
-        let pins: [SwiftPackage]
+        let pins: [SwiftPackageV1]
     }
 
     let object: Pins
     let version: Int
 }
 
-extension SwiftPackage {
+struct SwiftPackageV2: Decodable {
+    struct State: Decodable {
+        let branch: String?
+        let revision: String?
+        let version: String?
+    }
+    
+    let identity: String
+    let location: String
+    let state: State
+}
 
+struct ResolvedPackagesV2: Decodable {
+    let pins: [SwiftPackageV2]
+    let version: Int
+}
+
+extension SwiftPackage {
     static func loadPackages(_ content: String) -> [SwiftPackage] {
         guard let data = content.data(using: .utf8) else { return [] }
-        guard let resolvedPackages = try? JSONDecoder().decode(ResolvedPackages.self, from: data) else { return [] }
-
-        return resolvedPackages.object.pins
+        if let resolvedPackagesV1 = try? JSONDecoder().decode(ResolvedPackagesV1.self, from: data) {
+            return resolvedPackagesV1.object.pins.map {
+                SwiftPackage(package: $0.package, repositoryURL: $0.repositoryURL, revision: $0.state.revision, version: $0.state.version)
+            }
+        }
+        else if let resolvedPackagesV2 = try? JSONDecoder().decode(ResolvedPackagesV2.self, from: data) {
+            return resolvedPackagesV2.pins.map {
+                SwiftPackage(package: $0.identity, repositoryURL: $0.location, revision: $0.state.revision, version: $0.state.version)
+            }
+        }
+        else {
+            return []
+        }
     }
 
     func toGitHub(renames: [String: String]) -> GitHub? {
@@ -56,6 +89,6 @@ extension SwiftPackage {
         return GitHub(name: name,
                       nameSpecified: renames[name] ?? package,
                       owner: owner,
-                      version: state.version)
+                      version: version)
     }
 }

--- a/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
+++ b/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
@@ -10,8 +10,7 @@ import XCTest
 @testable import LicensePlistCore
 
 class SwiftPackageManagerTests: XCTestCase {
-
-    func testDecoding() throws {
+    func testDecodingV1() throws {
         let jsonString = """
             {
               "package": "APIKit",
@@ -25,7 +24,7 @@ class SwiftPackageManagerTests: XCTestCase {
         """
 
         let data = try XCTUnwrap(jsonString.data(using: .utf8))
-        let package = try JSONDecoder().decode(SwiftPackage.self, from: data)
+        let package = try JSONDecoder().decode(SwiftPackageV1.self, from: data)
 
         XCTAssertEqual(package.package, "APIKit")
         XCTAssertEqual(package.repositoryURL, "https://github.com/ishkawa/APIKit.git")
@@ -33,7 +32,7 @@ class SwiftPackageManagerTests: XCTestCase {
         XCTAssertEqual(package.state.version, "4.1.0")
     }
 
-    func testDecodingOfURLWithDots() throws {
+    func testDecodingOfURLWithDotsV1() throws {
         let jsonString = """
             {
               "package": "R.swift.Library",
@@ -47,15 +46,15 @@ class SwiftPackageManagerTests: XCTestCase {
         """
 
         let data = try XCTUnwrap(jsonString.data(using: .utf8))
-        let package = try JSONDecoder().decode(SwiftPackage.self, from: data)
+        let package = try JSONDecoder().decode(SwiftPackageV1.self, from: data)
 
         XCTAssertEqual(package.package, "R.swift.Library")
         XCTAssertEqual(package.repositoryURL, "https://github.com/mac-cain13/R.swift.Library")
         XCTAssertEqual(package.state.revision, "3365947d725398694d6ed49f2e6622f05ca3fc0f")
-        XCTAssertEqual(package.state.version, nil)
+        XCTAssertNil(package.state.version)
     }
 
-    func testDecodingOptionalVersion() throws {
+    func testDecodingOptionalVersionV1() throws {
         let jsonString = """
             {
               "package": "APIKit",
@@ -69,19 +68,66 @@ class SwiftPackageManagerTests: XCTestCase {
         """
 
         let data = try XCTUnwrap(jsonString.data(using: .utf8))
-        let package = try JSONDecoder().decode(SwiftPackage.self, from: data)
+        let package = try JSONDecoder().decode(SwiftPackageV1.self, from: data)
 
         XCTAssertEqual(package.package, "APIKit")
         XCTAssertEqual(package.repositoryURL, "https://github.com/ishkawa/APIKit.git")
         XCTAssertEqual(package.state.revision, "86d51ecee0bc0ebdb53fb69b11a24169a69097ba")
         XCTAssertEqual(package.state.branch, "master")
-        XCTAssertEqual(package.state.version, nil)
+        XCTAssertNil(package.state.version)
+    }
+    
+    func testDecodingWithVersionV2() throws {
+        let jsonString = """
+            {
+              "identity" : "APIKit",
+              "kind" : "remoteSourceControl",
+              "location" : "https://github.com/ishkawa/APIKit.git",
+              "state" : {
+                "revision" : "86d51ecee0bc0ebdb53fb69b11a24169a69097ba",
+                "version" : "4.1.0"
+              }
+            }
+        """
+
+        let data = try XCTUnwrap(jsonString.data(using: .utf8))
+        let package = try JSONDecoder().decode(SwiftPackageV2.self, from: data)
+
+        XCTAssertEqual(package.identity, "APIKit")
+        XCTAssertEqual(package.location, "https://github.com/ishkawa/APIKit.git")
+        XCTAssertEqual(package.state.revision, "86d51ecee0bc0ebdb53fb69b11a24169a69097ba")
+        XCTAssertNil(package.state.branch)
+        XCTAssertEqual(package.state.version, "4.1.0")
+    }
+    
+    func testDecodingWithBranchV2() throws {
+        let jsonString = """
+            {
+              "identity" : "APIKit",
+              "kind" : "remoteSourceControl",
+              "location" : "https://github.com/ishkawa/APIKit.git",
+              "state" : {
+                "branch" : "master",
+                "revision" : "86d51ecee0bc0ebdb53fb69b11a24169a69097ba"
+              }
+            }
+        """
+
+        let data = try XCTUnwrap(jsonString.data(using: .utf8))
+        let package = try JSONDecoder().decode(SwiftPackageV2.self, from: data)
+
+        XCTAssertEqual(package.identity, "APIKit")
+        XCTAssertEqual(package.location, "https://github.com/ishkawa/APIKit.git")
+        XCTAssertEqual(package.state.revision, "86d51ecee0bc0ebdb53fb69b11a24169a69097ba")
+        XCTAssertEqual(package.state.branch, "master")
+        XCTAssertNil(package.state.version)
     }
 
     func testConvertToGithub() {
         let package = SwiftPackage(package: "Commander",
                                    repositoryURL: "https://github.com/kylef/Commander.git",
-                                   state: SwiftPackage.State(branch: nil, revision: "e5b50ad7b2e91eeb828393e89b03577b16be7db9", version: "0.8.0"))
+                                   revision: "e5b50ad7b2e91eeb828393e89b03577b16be7db9",
+                                   version: "0.8.0")
         let result = package.toGitHub(renames: [:])
         XCTAssertEqual(result, GitHub(name: "Commander", nameSpecified: "Commander", owner: "kylef", version: "0.8.0"))
     }
@@ -89,7 +135,8 @@ class SwiftPackageManagerTests: XCTestCase {
     func testConvertToGithubNameWithDots() {
         let package = SwiftPackage(package: "R.swift.Library",
                                    repositoryURL: "https://github.com/mac-cain13/R.swift.Library",
-                                   state: SwiftPackage.State(branch: nil, revision: "3365947d725398694d6ed49f2e6622f05ca3fc0f", version: nil))
+                                   revision: "3365947d725398694d6ed49f2e6622f05ca3fc0f",
+                                   version: nil)
         let result = package.toGitHub(renames: [:])
         XCTAssertEqual(result, GitHub(name: "R.swift.Library", nameSpecified: "R.swift.Library", owner: "mac-cain13", version: nil))
     }
@@ -97,7 +144,8 @@ class SwiftPackageManagerTests: XCTestCase {
     func testConvertToGithubSSH() {
         let package = SwiftPackage(package: "LicensePlist",
                                    repositoryURL: "git@github.com:mono0926/LicensePlist.git",
-                                   state: SwiftPackage.State(branch: nil, revision: "3365947d725398694d6ed49f2e6622f05ca3fc0e", version: nil))
+                                   revision: "3365947d725398694d6ed49f2e6622f05ca3fc0e",
+                                   version: nil)
         let result = package.toGitHub(renames: [:])
         XCTAssertEqual(result, GitHub(name: "LicensePlist", nameSpecified: "LicensePlist", owner: "mono0926", version: nil))
     }
@@ -105,7 +153,8 @@ class SwiftPackageManagerTests: XCTestCase {
     func testConvertToGithubPackageName() {
         let package = SwiftPackage(package: "IterableSDK",
                                    repositoryURL: "https://github.com/Iterable/swift-sdk",
-                                   state: SwiftPackage.State(branch: nil, revision: "3365947d725398694d6ed49f2e6622f05ca3fc0e", version: nil))
+                                   revision: "3365947d725398694d6ed49f2e6622f05ca3fc0e",
+                                   version: nil)
         let result = package.toGitHub(renames: [:])
         XCTAssertEqual(result, GitHub(name: "swift-sdk", nameSpecified: "IterableSDK", owner: "Iterable", version: nil))
     }
@@ -113,7 +162,8 @@ class SwiftPackageManagerTests: XCTestCase {
     func testConvertToGithubRenames() {
         let package = SwiftPackage(package: "IterableSDK",
                                    repositoryURL: "https://github.com/Iterable/swift-sdk",
-                                   state: SwiftPackage.State(branch: nil, revision: "3365947d725398694d6ed49f2e6622f05ca3fc0e", version: nil))
+                                   revision: "3365947d725398694d6ed49f2e6622f05ca3fc0e",
+                                   version: nil)
         let result = package.toGitHub(renames: ["swift-sdk": "NAME"])
         XCTAssertEqual(result, GitHub(name: "swift-sdk", nameSpecified: "NAME", owner: "Iterable", version: nil))
     }
@@ -121,14 +171,14 @@ class SwiftPackageManagerTests: XCTestCase {
     func testRename() {
         let package = SwiftPackage(package: "Commander",
                                    repositoryURL: "https://github.com/kylef/Commander.git",
-                                   state: SwiftPackage.State(branch: nil,
-                                                             revision: "e5b50ad7b2e91eeb828393e89b03577b16be7db9", version: "0.8.0"))
+                                   revision: "e5b50ad7b2e91eeb828393e89b03577b16be7db9",
+                                   version: "0.8.0")
         let result = package.toGitHub(renames: ["Commander": "RenamedCommander"])
         XCTAssertEqual(result, GitHub(name: "Commander", nameSpecified: "RenamedCommander", owner: "kylef", version: "0.8.0"))
     }
 
     func testInvalidURL() {
-        let package = SwiftPackage(package: "Google", repositoryURL: "http://www.google.com", state: SwiftPackage.State(branch: nil, revision: "", version: "0.0.0"))
+        let package = SwiftPackage(package: "Google", repositoryURL: "http://www.google.com", revision: "", version: "0.0.0")
         let result = package.toGitHub(renames: [:])
         XCTAssertNil(result)
     }
@@ -136,7 +186,8 @@ class SwiftPackageManagerTests: XCTestCase {
     func testNonGithub() {
         let package = SwiftPackage(package: "Bitbucket",
                                    repositoryURL: "https://mbuchetics@bitbucket.org/mbuchetics/adventofcode2018.git",
-                                   state: SwiftPackage.State(branch: nil, revision: "", version: "0.0.0"))
+                                   revision: "",
+                                   version: "0.0.0")
         let result = package.toGitHub(renames: [:])
         XCTAssertNil(result)
     }
@@ -153,11 +204,13 @@ class SwiftPackageManagerTests: XCTestCase {
         let packageFirst = try XCTUnwrap(packages.first)
         XCTAssertEqual(packageFirst, SwiftPackage(package: "APIKit",
                                                   repositoryURL: "https://github.com/ishkawa/APIKit.git",
-                                                  state: SwiftPackage.State(branch: nil, revision: "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4", version: "5.2.0")))
+                                                  revision: "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4",
+                                                  version: "5.2.0"))
         let packageLast = try XCTUnwrap(packages.last)
         XCTAssertEqual(packageLast, SwiftPackage(package: "Yaml",
                                                  repositoryURL: "https://github.com/behrang/YamlSwift.git",
-                                                 state: SwiftPackage.State(branch: nil, revision: "287f5cab7da0d92eb947b5fd8151b203ae04a9a3", version: "3.4.4")))
+                                                 revision: "287f5cab7da0d92eb947b5fd8151b203ae04a9a3",
+                                                 version: "3.4.4"))
 
     }
 }


### PR DESCRIPTION
Swift Package Manager 5.6, bundled with Xcode 13.3 (currently in beta), updates the `Package.resolved` format to a new version 2. The JSON itself slightly changes, preventing LicensePlist from extracting correct dependency information.

This PR adds support for the new V2 format while preserving compatibility with version 1. Any feedback or improvement proposals are of course welcome.

Thank you very much for considering this PR and for this really helpful tool.

## Format changes

While the `Package.resolved` JSON V2 format is quite similar to V1, the `package` field has been replaced with a similar `identity` field:

```
// Version 1
{
  "package": "AppCenter",
  "repositoryURL": "https://github.com/microsoft/appcenter-sdk-apple.git",
  "state": {
    "branch": null,
    "revision": "b84bc8a39ff04bc8d5ae7b4d230c171c562891aa",
    "version": "4.4.1"
  }
}

// Version 2
{
  "identity" : "appcenter-sdk-apple",
  "kind" : "remoteSourceControl",
  "location" : "https://github.com/microsoft/appcenter-sdk-apple.git",
  "state" : {
    "revision" : "b84bc8a39ff04bc8d5ae7b4d230c171c562891aa",
    "version" : "4.4.1"
  }
}
```

Its value reflects the repository name more than the package name, thus the output delivered by license-plist slightly changes in comparison to the output generated from V1 format.

## Code changes

I added a few internal types to parse the V2 format while renaming existing types used to parse the V1 format. I kept `SwiftPackage` to consolidate common dependency information. V1 and V2 parsing are attempted in sequence, with their results simply mapped to this common type. No other changes are required.

## Test suite

I added a few test cases for the V2 format and added a V1 suffix to existing tests.