### PR TITLE
Add --add-sources option

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ You can see options by `license-plist --help`.
 
 <img src="Screenshots/list_version.png" width="320" height="568" alt="License list with versions">
 
+#### `--add-sources`
+
+- Default: false
+- Adds the source of the library to the output if there is one. The source for GitHub and CocoaPods libraries is generated. Manual libraries use the optional source field.
+
 #### `--suppress-opening-directory`
 
 - Default: false

--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -64,6 +64,9 @@ struct LicensePlist: ParsableCommand {
     var addVersionNumbers = false
 
     @Flag(name: .long)
+    var addSources = false
+    
+    @Flag(name: .long)
     var suppressOpeningDirectory = false
 
     @Flag(name: .long)
@@ -80,6 +83,7 @@ struct LicensePlist: ParsableCommand {
         config.suppressOpeningDirectory = suppressOpeningDirectory
         config.singlePage = singlePage
         config.failIfMissingLicense = failIfMissingLicense
+        config.addSources = addSources
         let options = Options(outputPath: URL(fileURLWithPath: outputPath),
                               cartfilePath: URL(fileURLWithPath: cartfilePath),
                               mintfilePath: URL(fileURLWithPath: mintfilePath),

--- a/Sources/LicensePlistCore/Entity/CocoaPods.swift
+++ b/Sources/LicensePlistCore/Entity/CocoaPods.swift
@@ -6,21 +6,13 @@ public struct CocoaPods: Library {
     public let name: String
     public let nameSpecified: String?
     public let version: String?
-    public let source: String?
-    
-    public init(name: String, nameSpecified: String?, version: String?) {
-        self.name = name
-        self.nameSpecified = nameSpecified
-        self.version = version
-        self.source = "https://cocoapods.org/pods/\(name)"
-    }
+    public var source: String? { "https://cocoapods.org/pods/\(name)"  }
 }
 
 extension CocoaPods {
     public static func==(lhs: CocoaPods, rhs: CocoaPods) -> Bool {
         return lhs.name == rhs.name &&
-        lhs.nameSpecified == rhs.nameSpecified &&
-        lhs.version == rhs.version &&
-        lhs.source == rhs.source
+            lhs.nameSpecified == rhs.nameSpecified &&
+            lhs.version == rhs.version
     }
 }

--- a/Sources/LicensePlistCore/Entity/CocoaPods.swift
+++ b/Sources/LicensePlistCore/Entity/CocoaPods.swift
@@ -6,12 +6,21 @@ public struct CocoaPods: Library {
     public let name: String
     public let nameSpecified: String?
     public let version: String?
+    public let source: String?
+    
+    public init(name: String, nameSpecified: String?, version: String?) {
+        self.name = name
+        self.nameSpecified = nameSpecified
+        self.version = version
+        self.source = "https://cocoapods.org/pods/\(name)"
+    }
 }
 
 extension CocoaPods {
     public static func==(lhs: CocoaPods, rhs: CocoaPods) -> Bool {
         return lhs.name == rhs.name &&
-            lhs.nameSpecified == rhs.nameSpecified &&
-            lhs.version == rhs.version
+        lhs.nameSpecified == rhs.nameSpecified &&
+        lhs.version == rhs.version &&
+        lhs.source == rhs.source
     }
 }

--- a/Sources/LicensePlistCore/Entity/Config.swift
+++ b/Sources/LicensePlistCore/Entity/Config.swift
@@ -9,6 +9,7 @@ public struct Config {
     let renames: [String: String]
     public var force = false
     public var addVersionNumbers = false
+    public var addSources = false
     public var suppressOpeningDirectory = false
     public var singlePage = false
     public var failIfMissingLicense = false

--- a/Sources/LicensePlistCore/Entity/GitHub.swift
+++ b/Sources/LicensePlistCore/Entity/GitHub.swift
@@ -7,24 +7,15 @@ public struct GitHub: Library {
     public let nameSpecified: String?
     var owner: String
     public let version: String?
-    public let source: String?
-    
-    public init(name: String, nameSpecified: String?, owner: String, version: String?) {
-        self.name = name
-        self.nameSpecified = nameSpecified
-        self.owner = owner
-        self.version = version
-        self.source = "https://github.com/\(owner)/\(name)"
-    }
+    public var source: String? { "https://github.com/\(owner)/\(name)" }
 }
 
 extension GitHub {
     public static func==(lhs: GitHub, rhs: GitHub) -> Bool {
         return lhs.name == rhs.name &&
-        lhs.nameSpecified == rhs.nameSpecified &&
-        lhs.owner == rhs.owner &&
-        lhs.version == rhs.version &&
-        lhs.source == rhs.source
+            lhs.nameSpecified == rhs.nameSpecified &&
+            lhs.owner == rhs.owner &&
+            lhs.version == rhs.version
     }
 }
 

--- a/Sources/LicensePlistCore/Entity/GitHub.swift
+++ b/Sources/LicensePlistCore/Entity/GitHub.swift
@@ -7,20 +7,30 @@ public struct GitHub: Library {
     public let nameSpecified: String?
     var owner: String
     public let version: String?
+    public let source: String?
+    
+    public init(name: String, nameSpecified: String?, owner: String, version: String?) {
+        self.name = name
+        self.nameSpecified = nameSpecified
+        self.owner = owner
+        self.version = version
+        self.source = "https://github.com/\(owner)/\(name)"
+    }
 }
 
 extension GitHub {
     public static func==(lhs: GitHub, rhs: GitHub) -> Bool {
         return lhs.name == rhs.name &&
-            lhs.nameSpecified == rhs.nameSpecified &&
-            lhs.owner == rhs.owner &&
-            lhs.version == rhs.version
+        lhs.nameSpecified == rhs.nameSpecified &&
+        lhs.owner == rhs.owner &&
+        lhs.version == rhs.version &&
+        lhs.source == rhs.source
     }
 }
 
 extension GitHub: CustomStringConvertible {
     public var description: String {
-        return "name: \(name), nameSpecified: \(nameSpecified ?? ""), owner: \(owner), version: \(version ?? "")"
+        return "name: \(name), nameSpecified: \(nameSpecified ?? ""), owner: \(owner), version: \(version ?? ""), source: \(source ?? "")"
     }
 }
 
@@ -57,9 +67,10 @@ extension GitHub {
                 return version
             }()
             let name = nsContent.substring(with: match.range(at: 2))
+            let owner = nsContent.substring(with: match.range(at: 1))
             return GitHub(name: name,
                           nameSpecified: renames[name],
-                          owner: nsContent.substring(with: match.range(at: 1)),
+                          owner: owner,
                           version: version)
             }
             .compactMap { $0 }

--- a/Sources/LicensePlistCore/Entity/Library.swift
+++ b/Sources/LicensePlistCore/Entity/Library.swift
@@ -4,6 +4,7 @@ import LoggerAPI
 
 public protocol Library: HasName, Hashable {
     var version: String? { get }
+    var source: String? { get }
 }
 
 extension Library {

--- a/Sources/LicensePlistCore/Entity/License.swift
+++ b/Sources/LicensePlistCore/Entity/License.swift
@@ -5,6 +5,7 @@ import LoggerAPI
 public protocol LicenseInfo: HasName {
     var body: String { get }
     var version: String? { get }
+    var source: String? { get }
     var bodyEscaped: String { get }
 }
 
@@ -28,6 +29,7 @@ extension License {
     public var name: String { return library.name }
     public var nameSpecified: String? { return library.nameSpecified }
     public var version: String? { return library.version }
+    public var source: String? { return library.source }
     public var bodyEscaped: String {
         return body
             .replacingOccurrences(of: "&", with: "&amp;")

--- a/Sources/LicensePlistCore/Entity/LicenseHTMLHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicenseHTMLHolder.swift
@@ -20,11 +20,19 @@ struct LicenseHTMLHolder {
 
 """
         licenses.forEach { license in
-            html += """
+            if options.config.addSources, let source = license.source {
+                html += """
+        <a href="\(source)"<h2>\(license.name(withVersion: options.config.addVersionNumbers).htmlEscape())</h2></a>
+        <pre>\(license.body.htmlEscape())</pre>
+
+"""
+            } else {
+                html += """
         <h2>\(license.name(withVersion: options.config.addVersionNumbers).htmlEscape())</h2>
         <pre>\(license.body.htmlEscape())</pre>
 
 """
+            }
         }
         html += """
     </body>

--- a/Sources/LicensePlistCore/Entity/LicenseMarkdownHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicenseMarkdownHolder.swift
@@ -6,7 +6,11 @@ struct LicenseMarkdownHolder {
     static func load(licenses: [LicenseInfo], options: Options) -> LicenseMarkdownHolder {
         var markdown = "# Acknowledgements\nThis project makes use of the following third party libraries:\n\n"
         licenses.forEach { license in
-            markdown += "## \(license.name(withVersion: options.config.addVersionNumbers))\n\n\(license.body)\n\n"
+            if options.config.addSources, let source = license.source {
+                markdown += "## [\(license.name(withVersion: options.config.addVersionNumbers))](\(source))\n\n\(license.body)\n\n"
+            } else {
+                markdown += "## \(license.name(withVersion: options.config.addVersionNumbers))\n\n\(license.body)\n\n"
+            }
         }
         return LicenseMarkdownHolder(markdown: markdown)
     }

--- a/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
+++ b/Sources/LicensePlistCore/Entity/LicensePlistHolder.swift
@@ -18,7 +18,7 @@ struct LicensePlistHolder {
                                                        options: 0)
         let items: [(LicenseInfo, Data)] = licenses.map { license in
             let lineRegex = try! NSRegularExpression(pattern: "^\\s*[-_*=]{3,}\\s*$", options: [])
-            let item = ["PreferenceSpecifiers":
+            var item = ["PreferenceSpecifiers":
                             license.body
                             .components(separatedBy: "\n\n")
                             .split(whereSeparator: { (possibleHorizontalLine) -> Bool in
@@ -32,6 +32,10 @@ struct LicensePlistHolder {
                                 ["Type": "PSGroupSpecifier", "FooterText": paragraph]
                             }
             ]
+            
+            if options.config.addSources, let source = license.source {
+                item["PreferenceSpecifiers"]?.insert(["Type": "PSTitleValueSpecifier", "Key": "\(license.name)-source", "DefaultValue": source, "Title": "Source"], at: 0)
+            }
             let value = try! PropertyListSerialization.data(fromPropertyList: item, format: .xml, options: 0)
             return (license, value)
         }


### PR DESCRIPTION
Adds an optional `--add-sources` option that adds the source to the generated output. Defaults to `false`.

- GitHub sources are generated using the `owner` and `name`
- CocoaPods source is generated via the pod name and links to https://cocoapods.org
- Manual sources already have an optional source flag, which is used when adding sources