### PR TITLE
Add --silent-mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ You can see options by `license-plist --help`.
 - Default: false
 - If there is even one package for which a license cannot be found, LicensePlist returns exit code 1.
 
+#### `--silence-mode`
+
+- Default: false
+- By adding `--silence-mode` flag, the output of the logger will not print.
+
 ### Integrate into build
 
 Add a `Run Script Phase` to `Build Phases`:

--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -74,9 +74,16 @@ struct LicensePlist: ParsableCommand {
 
     @Flag(name: .long)
     var failIfMissingLicense = false
+    
+    @Flag(name: .long)
+    var silenceMode = false
 
     func run() throws {
-        Logger.configure()
+        
+        if !silenceMode {
+            Logger.configure()
+        }
+        
         var config = loadConfig(configPath: URL(fileURLWithPath: configPath))
         config.force = force
         config.addVersionNumbers = addVersionNumbers


### PR DESCRIPTION
Add an optional `--silent-mode` option that disables the console log. Defaults to `false`.