### PR TITLE
Update dependencies and migrate package to Swift 5.3 (Xcode 12)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ishkawa/APIKit.git",
         "state": {
           "branch": null,
-          "revision": "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4",
-          "version": "5.2.0"
+          "revision": "4e7f42d93afb787b0bc502171f9b5c12cf49d0ca",
+          "version": "5.3.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Kitura/HeliumLogger.git",
         "state": {
           "branch": null,
-          "revision": "55fd2f0b70793017acee853c53cfcf8da0bd8d8d",
-          "version": "1.9.200"
+          "revision": "fc2a71597ae974da5282d751bcc11965964bccce",
+          "version": "2.0.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Kitura/LoggerAPI.git",
         "state": {
           "branch": null,
-          "revision": "e82d34eab3f0b05391082b11ea07d3b70d2f65bb",
-          "version": "1.9.200"
+          "revision": "4e6b45e850ffa275e8e26a24c6454fd709d5b6ac",
+          "version": "2.0.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
-          "version": "1.0.1"
+          "revision": "82905286cc3f0fa8adc4674bf49437cab65a8373",
+          "version": "1.1.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/Kitura/swift-html-entities.git",
         "state": {
           "branch": null,
-          "revision": "2b14531d0c36dbb7c1c45a4d38db9c2e7898a307",
-          "version": "3.0.200"
+          "revision": "d8ca73197f59ce260c71bd6d7f6eb8bbdccf508b",
+          "version": "4.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.1
+// swift-tools-version:5.3
 
 import PackageDescription
 
@@ -10,22 +10,22 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git",
-                 from: "1.0.1"),
+                 from: "1.1.1"),
         .package(url: "https://github.com/ishkawa/APIKit.git",
-                 from: "5.2.0"),
+                 from: "5.3.0"),
         .package(url: "https://github.com/Kitura/HeliumLogger.git",
-                 from: "1.9.0"),
+                 from: "2.0.0"),
         .package(url: "https://github.com/behrang/YamlSwift.git",
                  from: "3.4.4"),
         .package(url: "https://github.com/Kitura/swift-html-entities.git",
-                 from: "3.0.14"),
+                 from: "4.0.1"),
     ],
     targets: [
         .target(
             name: "LicensePlist",
             dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 "LicensePlistCore",
-                "ArgumentParser",
                 "HeliumLogger",
             ]
         ),
@@ -34,14 +34,15 @@ let package = Package(
             dependencies: [
                 "APIKit",
                 "HeliumLogger",
-                "HTMLEntities",
-                "Yaml",
+                .product(name: "HTMLEntities", package: "swift-html-entities"),
+                .product(name: "Yaml", package: "YamlSwift")
             ]
         ),
         .testTarget(
             name: "LicensePlistTests",
             dependencies: ["LicensePlistCore"],
             exclude: [
+                "Resources",
                 "XcodeProjects",
             ]
         ),

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 
 ![platforms](https://img.shields.io/badge/platforms-iOS-333333.svg)
 [![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/mono0926/NativePopup/master/LICENSE)
-[![Language: Swift 4.1](https://img.shields.io/badge/swift-4.1-4BC51D.svg?style=flat)](https://developer.apple.com/swift)
-[![Language: Swift 4.2](https://img.shields.io/badge/swift-4.2-4BC51D.svg?style=flat)](https://developer.apple.com/swift)
-[![Language: Swift 5.0](https://img.shields.io/badge/swift-5.0-4BC51D.svg?style=flat)](https://developer.apple.com/swift)
+[![Language: Swift 5.3](https://img.shields.io/badge/swift-5.3-4BC51D.svg?style=flat)](https://developer.apple.com/swift)
 [![Swift Package Manager compatible](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
 
 [![Lint](https://github.com/mono0926/LicensePlist/actions/workflows/lint.yml/badge.svg)](https://github.com/mono0926/LicensePlist/actions/workflows/lint.yml)

--- a/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
@@ -22,8 +22,8 @@ class SwiftPackageFileReaderTests: XCTestCase {
                 "repositoryURL": "https://github.com/ishkawa/APIKit.git",
                 "state": {
                   "branch": null,
-                  "revision": "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4",
-                  "version": "5.2.0"
+                  "revision": "4e7f42d93afb787b0bc502171f9b5c12cf49d0ca",
+                  "version": "5.3.0"
                 }
               },
               {
@@ -31,8 +31,8 @@ class SwiftPackageFileReaderTests: XCTestCase {
                 "repositoryURL": "https://github.com/Kitura/HeliumLogger.git",
                 "state": {
                   "branch": null,
-                  "revision": "55fd2f0b70793017acee853c53cfcf8da0bd8d8d",
-                  "version": "1.9.200"
+                  "revision": "fc2a71597ae974da5282d751bcc11965964bccce",
+                  "version": "2.0.0"
                 }
               },
               {
@@ -40,8 +40,8 @@ class SwiftPackageFileReaderTests: XCTestCase {
                 "repositoryURL": "https://github.com/Kitura/LoggerAPI.git",
                 "state": {
                   "branch": null,
-                  "revision": "e82d34eab3f0b05391082b11ea07d3b70d2f65bb",
-                  "version": "1.9.200"
+                  "revision": "4e6b45e850ffa275e8e26a24c6454fd709d5b6ac",
+                  "version": "2.0.0"
                 }
               },
               {
@@ -49,8 +49,8 @@ class SwiftPackageFileReaderTests: XCTestCase {
                 "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
                 "state": {
                   "branch": null,
-                  "revision": "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
-                  "version": "1.0.1"
+                  "revision": "82905286cc3f0fa8adc4674bf49437cab65a8373",
+                  "version": "1.1.1"
                 }
               },
               {
@@ -58,8 +58,8 @@ class SwiftPackageFileReaderTests: XCTestCase {
                 "repositoryURL": "https://github.com/Kitura/swift-html-entities.git",
                 "state": {
                   "branch": null,
-                  "revision": "2b14531d0c36dbb7c1c45a4d38db9c2e7898a307",
-                  "version": "3.0.200"
+                  "revision": "d8ca73197f59ce260c71bd6d7f6eb8bbdccf508b",
+                  "version": "4.0.1"
                 }
               },
               {

--- a/formula.rb.tmpl
+++ b/formula.rb.tmpl
@@ -8,5 +8,5 @@ class LicensePlist < Formula
     system "make", "install", "PREFIX=#{prefix}"
   end
 
-  depends_on :xcode => ["8.3", :build]
+  depends_on :xcode => ["12.0", :build]
 end


### PR DESCRIPTION
* Update package to Swift 5.3
* Xcode 12 is required
* Drop support for Swift 4.x