### PR TITLE
Improve license type detection for CocoaPods

### DIFF
--- a/Sources/LicensePlistCore/Entity/LicenseType.swift
+++ b/Sources/LicensePlistCore/Entity/LicenseType.swift
@@ -22,6 +22,6 @@ public enum LicenseType: String, CaseIterable {
 extension LicenseType {
 
     init(id: String?) {
-        self = Self(rawValue: id ?? "") ?? .unknown
+        self = Self(rawValue: id ?? "") ?? Self.allCases.first(where: { $0.rawValue.replacingOccurrences(of: "-", with: " ") == id }) ?? .unknown
     }
 }


### PR DESCRIPTION
This improve the detection of CocoaPods-based licenses. It fix the following issue:

- The Apache license looks in CocoaPods like `Apache 2.0`
- The Apache license looks in SPM like `Apache-2.0`