### PR TITLE
feat: support granular excludes rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ You can see options by `license-plist --help`.
 - Default: `license_plist.yml`
 - You can specify GitHub libraries(introduced by hand) and excluded libraries
     - [Example is here](https://github.com/mono0926/LicensePlist/blob/master/Tests/LicensePlistTests/Resources/license_plist.yml)
+    - See [Configuration](#Configuration) for more information
 
 #### `--prefix`
 
@@ -215,6 +216,118 @@ Alternatively, if you've installed LicensePlist via CocoaPods the script should 
 if [ $CONFIGURATION = "Debug" ]; then
 ${PODS_ROOT}/LicensePlist/license-plist --output-path $PRODUCT_NAME/Settings.bundle --github-token YOUR_GITHUB_TOKEN
 fi
+```
+
+## Configuration
+
+### Manual GitHub source
+
+A GitHub source can be explicitly defined to include the license in the scenario where it can't be inferred from your dependency files.
+
+#### Examples
+
+```yml
+github:
+  - owner: mono0926
+    name: LicensePlist
+    version: 1.2.0
+```
+
+### Manual License Body
+
+If you need to include a license that isn't available on GitHub, you can place the license text in the config file to be included in the output.
+The license text can also be read from a local file, to keep the config file clean.
+
+#### Examples
+
+License body directly in the config file:
+
+```yml
+manual:
+  - source: https://webrtc.googlesource.com/src
+    name: WebRTC
+    version: M61
+    body: |-
+      Copyright (c) 2011, The WebRTC project authors. All rights reserved.
+      ...
+      ...
+      ...
+```
+
+License body in local file:
+
+```yml
+manual:
+  - name: "Dummy License File"
+    file: "dummy_license.txt"
+```
+
+### Excludes
+
+Excludes can be defined to exclude matching libraries from the final output.
+An exclude is a dictionary containing any combination of `name`, `source`, `owner`, or `licenseType`.
+
+When using the dictionary format:
+
+- The exclusion rule is only applied if _all_ properties match for a dependency. eg, `(name: LicensePlist) AND (owner: mono0926)`
+- Any property can be either a string or a regular expression. 
+
+#### Examples
+
+Exclude a package by name:
+
+```yml
+exclude:
+  - name: LicensePlist
+```
+
+Exclude packages using a specific license:
+
+```yml
+exclude:
+  - licenseType: "Apache 2.0"
+```
+
+Exclude packages using any matching licenses:
+
+```yml
+exclude:
+  - licenseType: /BSD/
+```
+
+Exclude packages from a specific github owner:
+
+```yml
+exclude:
+  - owner: mycompany
+```
+
+Exclude packages from a specific github owner containing matching licenses:
+
+```yml
+exclude:
+  - owner: mycompany
+    licenseType: /^(?!.*MIT).*$/ # this regex excludes packages that do NOT use the MIT license
+``` 
+
+Exclude a package from a specific github owner and repo:
+
+```yml
+exclude:
+  - owner: mycompany
+    name: private-repo
+```
+
+### Rename
+
+If a library name is unsuitable for the output bundle, you can explicitly rename it. This can be used when a library name is too vague, or if more human-readable names are needed.
+
+#### Examples
+
+```yml
+rename:
+  LicensePlist: License Plist # Rename LicensePlist to "License Plist"
+  WebRTC: Web RTC # Rename WebRTC to "Web RTC" (which is faulty, but used for test)
 ```
 
 ## Q&A

--- a/Sources/LicensePlistCore/Entity/Config.swift
+++ b/Sources/LicensePlistCore/Entity/Config.swift
@@ -5,7 +5,7 @@ import Yaml
 public struct Config {
     let githubs: [GitHub]
     let manuals: [Manual]
-    let excludes: [String]
+    let excludes: [Exclude]
     let renames: [String: String]
     public var force = false
     public var addVersionNumbers = false
@@ -14,11 +14,11 @@ public struct Config {
     public var singlePage = false
     public var failIfMissingLicense = false
 
-    public static let empty = Config(githubs: [], manuals: [], excludes: [], renames: [:])
+    public static let empty = Config(githubs: [], manuals: [], excludes: [Exclude](), renames: [:])
 
     public init(yaml: String, configBasePath: URL) {
         let value = try! Yaml.load(yaml)
-        let excludes = value["exclude"].array?.map { $0.string! } ?? []
+        let excludes = value["exclude"].array?.compactMap({ Exclude(from: $0) }) ?? []
         let renames = value["rename"].dictionary?.reduce([String: String]()) { sum, e in
             guard let from = e.key.string, let to = e.value.string else { return sum }
             var sum = sum
@@ -27,7 +27,7 @@ public struct Config {
             } ?? [:]
         let manuals = value["manual"].array ?? []
         let manualList = Manual.load(manuals, renames: renames, configBasePath: configBasePath)
-        let githubs = value["github"].array?.map { $0.string }.compactMap { $0 } ?? []
+        let githubs = value["github"].array?.compactMap { $0.string }.compactMap { $0 } ?? []
         let gitHubList = githubs.map { GitHub.load(.licensePlist(content: $0), renames: renames) }.flatMap { $0 }
         gitHubList.forEach {
             Log.warning("\($0.name) is specified by the depricated format. It will be removed at Version 2." +
@@ -49,27 +49,87 @@ public struct Config {
     }
 
     public init(githubs: [GitHub], manuals: [Manual], excludes: [String], renames: [String: String]) {
+        self.init(githubs: githubs, manuals: manuals, excludes: excludes.map({ Exclude(name: $0) }), renames: renames)
+    }
+
+    public init(githubs: [GitHub], manuals: [Manual], excludes: [Exclude], renames: [String: String]) {
         self.githubs = githubs
         self.manuals = manuals
         self.excludes = excludes
         self.renames = renames
     }
 
-    func excluded(name: String) -> Bool {
-        if excludes.contains(name) {
-            return true
-        }
-        for text in excludes {
-            if let pattern = type(of: self).extractRegex(text), let regex = try? NSRegularExpression(pattern: pattern, options: []) {
-                let nsName = name as NSString
-                let matches = regex.matches(in: name, options: [], range: NSRange(location: 0, length: nsName.length))
-                assert(matches.count <= 1)
-                if !matches.isEmpty {
-                    return true
-                }
+    func excluded(github: GitHub) -> Bool {
+        for exclude in excludes {
+            if matches(testString: github.name, matchString: exclude.name) &&
+                matches(testString: github.owner, matchString: exclude.owner) &&
+                matches(testString: github.source, matchString: exclude.source) &&
+                matches(testString: github.licenseType.rawValue, matchString: exclude.licenseType)
+            {
+                return true
             }
         }
         return false
+    }
+
+    func excluded(manual: Manual) -> Bool {
+        for exclude in excludes {
+            if matches(testString: manual.name, matchString: exclude.name) &&
+                matches(testString: manual.source, matchString: exclude.source) &&
+                matches(testString: manual.licenseType.rawValue, matchString: exclude.licenseType)
+            {
+                return true
+            }
+        }
+        return false
+    }
+
+    func excluded(cocoaPodsLicense: CocoaPodsLicense) -> Bool {
+        for exclude in excludes {
+            if matches(testString: cocoaPodsLicense.name, matchString: exclude.name) &&
+                matches(testString: cocoaPodsLicense.source, matchString: exclude.source) &&
+                matches(testString: cocoaPodsLicense.licenseType.rawValue, matchString: exclude.licenseType)
+            {
+                return true
+            }
+        }
+        return false
+    }
+
+    func excluded(name: String) -> Bool {
+        for exclude in excludes {
+            if matches(testString: name, matchString: exclude.name) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func matches(testString: String?, matchString: String?) -> Bool {
+        // If it's an exact match, short-circuit
+        if testString == matchString {
+            return true
+        }
+
+        // If matchString is nil, then the rule isn't specified and we ignore it
+        guard let matchString = matchString else {
+            return true
+        }
+
+        // If testString is nil, then there is nothing to test and the rule must fail
+        guard let testString = testString else {
+            return false
+        }
+
+        // If it wasn't an exact match, then try regular expression.
+        guard let pattern = type(of: self).extractRegex(matchString), let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+            return false
+        }
+
+        // If a regular expression is detected, test the string and return whether it matched the regex.
+        let matches = regex.matches(in: testString, options: [], range: NSRange(location: 0, length: testString.count))
+        assert(matches.count <= 1)
+        return matches.count == 1
     }
 
     static func extractRegex(_ text: String) -> String? {
@@ -90,12 +150,31 @@ public struct Config {
         return nsText.substring(with: match.range(at: 1))
     }
 
-    func filterExcluded<T: HasName>(_ names: [T]) -> [T] {
-        return names.filter {
-            let name = $0.name
-            let result = !excluded(name: name)
+    func filterExcluded(githubs: [GitHub]) -> [GitHub] {
+        return githubs.filter {
+            let result = !excluded(github: $0)
             if !result {
-                Log.warning("\(type(of: $0.self))'s \(name) was excluded according to config YAML.")
+                Log.warning("\(type(of: $0.self))'s \($0.name) was excluded according to config YAML.")
+            }
+            return result
+        }
+    }
+
+    func filterExcluded(manuals: [Manual]) -> [Manual] {
+        return manuals.filter {
+            let result = !excluded(manual: $0)
+            if !result {
+                Log.warning("\(type(of: $0.self))'s \($0.name) was excluded according to config YAML.")
+            }
+            return result
+        }
+    }
+
+    func filterExcluded(cocoaPodsLicenses: [CocoaPodsLicense]) -> [CocoaPodsLicense] {
+        return cocoaPodsLicenses.filter {
+            let result = !excluded(cocoaPodsLicense: $0)
+            if !result {
+                Log.warning("\(type(of: $0.self))'s \($0.name) was excluded according to config YAML.")
             }
             return result
         }
@@ -103,11 +182,11 @@ public struct Config {
 
     func apply(githubs: [GitHub]) -> [GitHub] {
         self.githubs.forEach { Log.warning("\($0.name) was loaded from config YAML.") }
-        return filterExcluded((self.githubs + githubs))
+        return filterExcluded(githubs: (self.githubs + githubs))
     }
 
     func applyManual(manuals: [Manual]) -> [Manual] {
-        return filterExcluded((self.manuals + manuals))
+        return filterExcluded(manuals: (self.manuals + manuals))
     }
 }
 

--- a/Sources/LicensePlistCore/Entity/Exclude.swift
+++ b/Sources/LicensePlistCore/Entity/Exclude.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Yaml
+import LoggerAPI
+
+public struct Exclude {
+    public let name: String?
+    public let owner: String?
+    public let source: String?
+    public let licenseType: String?
+
+    public init(name: String? = nil, owner: String? = nil, source: String? = nil, licenseType: String? = nil) {
+        self.name = name
+        self.owner = owner
+        self.source = source
+        self.licenseType = licenseType
+    }
+
+    public init?(from yaml: Yaml) {
+        if let name = yaml.string {
+            self.init(name: name, owner: nil, source: nil, licenseType: Optional<String>.none)
+            return
+        }
+
+        guard let dictionary = yaml.dictionary else {
+            Log.warning("Attempt to load exclude failed. Supported YAML types are String and Dictionary.")
+            return nil
+        }
+
+        let name = dictionary["name"]?.string
+        let owner = dictionary["owner"]?.string
+        let source = dictionary["source"]?.string
+        let licenseType = dictionary["licenseType"]?.string
+
+        if name == nil && owner == nil && source == nil && licenseType == nil {
+            Log.warning("Attempt to load exclude failed. At least one exclude matcher must be specified.")
+            return nil
+        }
+
+        self.init(name: name,
+                  owner: owner,
+                  source: source,
+                  licenseType: licenseType)
+    }
+}
+
+extension Exclude: Equatable {
+    public static func==(lhs: Self, rhs: Self) -> Bool {
+        return lhs.name == rhs.name &&
+            lhs.owner == rhs.owner &&
+            lhs.source == rhs.source &&
+            lhs.licenseType == rhs.licenseType
+    }
+}

--- a/Sources/LicensePlistCore/Entity/PlistInfo.swift
+++ b/Sources/LicensePlistCore/Entity/PlistInfo.swift
@@ -25,7 +25,7 @@ struct PlistInfo {
             .map { CocoaPodsLicense.load($0, versionInfo: podsVersionInfo, config: options.config) }
             .flatMap { $0 }
         let config = options.config
-        cocoaPodsLicenses = config.filterExcluded(licenses).sorted()
+        cocoaPodsLicenses = config.filterExcluded(cocoaPodsLicenses: licenses).sorted()
     }
 
     mutating func loadGitHubLibraries(file: GitHubLibraryConfigFile) {

--- a/Tests/LicensePlistTests/Entity/CocoaPodsTests.swift
+++ b/Tests/LicensePlistTests/Entity/CocoaPodsTests.swift
@@ -14,7 +14,7 @@ class CocoaPodsTests: XCTestCase {
         let content = try String(contentsOf: XCTUnwrap(URL(string: path)))
         let results = CocoaPodsLicense.load(content,
                                             versionInfo: VersionInfo(dictionary: ["Firebase": "1.2.3"]),
-                                            config: Config(githubs: [], manuals: [], excludes: [], renames: ["Firebase": "Firebase2"]))
+                                            config: Config(githubs: [], manuals: [], excludes: [Exclude](), renames: ["Firebase": "Firebase2"]))
         XCTAssertFalse(results.isEmpty)
         XCTAssertEqual(results.count, 11)
         let licenseFirst = try XCTUnwrap(results.first)

--- a/Tests/LicensePlistTests/Entity/ExcludeTests.swift
+++ b/Tests/LicensePlistTests/Entity/ExcludeTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import XCTest
+import Yaml
+@testable import LicensePlistCore
+
+class ExcludeTests: XCTestCase {
+
+    func testInit_yaml_dictionary() {
+        let testDict: [Yaml: Yaml] = [
+            "name": "LicensePlist",
+            "owner": "mono0926",
+            "source": "https://github.com/mono0926/LicensePlist",
+            "licenseType": "MIT",
+        ]
+        let yaml = Yaml.dictionary(testDict)
+        let exclude = Exclude(from: yaml)
+        XCTAssertNotNil(exclude)
+        XCTAssertEqual(exclude!.name, yaml["name"].string)
+        XCTAssertEqual(exclude!.owner, yaml["owner"].string)
+        XCTAssertEqual(exclude!.source, yaml["source"].string)
+        XCTAssertEqual(exclude!.licenseType, yaml["licenseType"].string)
+    }
+
+    func testInit_yaml_dictionary_missing_some_properties() {
+        let testDict: [Yaml: Yaml] = [
+            "name": "LicensePlist",
+            "owner": "mono0926",
+        ]
+        let yaml = Yaml.dictionary(testDict)
+        let exclude = Exclude(from: yaml)
+        XCTAssertNotNil(exclude)
+        XCTAssertEqual(exclude!.name, yaml["name"].string)
+        XCTAssertEqual(exclude!.owner, yaml["owner"].string)
+        XCTAssertNil(exclude!.source)
+        XCTAssertNil(exclude!.licenseType)
+    }
+
+    func testInit_yaml_no_properties() {
+        let testDict: [Yaml: Yaml] = [:]
+        let yaml = Yaml.dictionary(testDict)
+        let exclude = Exclude(from: yaml)
+        XCTAssertNil(exclude)
+    }
+
+    func testInit_yaml_invalid_properties() {
+        let testDict: [Yaml: Yaml] = ["invalid": "invalid"]
+        let yaml = Yaml.dictionary(testDict)
+        let exclude = Exclude(from: yaml)
+        XCTAssertNil(exclude)
+    }
+
+    func testInit_yaml_string() {
+        let testString = "LicensePlist"
+        let yaml = Yaml.string(testString)
+        let exclude = Exclude(from: yaml)
+        XCTAssertNotNil(exclude)
+        XCTAssertEqual(exclude!.name, testString)
+        XCTAssertNil(exclude!.owner)
+        XCTAssertNil(exclude!.source)
+        XCTAssertNil(exclude!.licenseType)
+    }
+
+    func testInit_yaml_invalid_yaml_type() {
+        let yaml = Yaml.bool(true)
+        let exclude = Exclude(from: yaml)
+        XCTAssertNil(exclude)
+    }
+
+    func testInit_yaml_invalid_license_type() {
+        let testDict: [Yaml: Yaml] = [
+            "licenseType": "invalid"
+        ]
+        let yaml = Yaml.dictionary(testDict)
+        let exclude = Exclude(from: yaml)
+        XCTAssertNotNil(exclude)
+    }
+}


### PR DESCRIPTION
- Add support for excluding packages based on source URL, github owner, name, or license type
- Add configuration documentation

[Test-license-plist-2022.04.26_18-01-10--0700.xcresult.zip](https://github.com/mono0926/LicensePlist/files/8567840/Test-license-plist-2022.04.26_18-01-10--0700.xcresult.zip)