### PR TITLE
Add description for `--package-paths` option into readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ You can see options by `license-plist --help`.
 - Default: `Package.swift`
 - `LicensePlist` tries to find `YourProjectName.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` and `YourProjectName.xcworkspace/xcshareddata/swiftpm/Package.resolved`, then uses new one.
 
+#### `--package-paths`
+
+- Support for multiple `Pakckage.swift`
+- Example: `license-plist --package-paths /path/to/package1/Package.swift /path/to/package2/Package.swift`
+
 #### `--xcodeproj-path`
 
 - Default: `"*.xcodeproj"`

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You can see options by `license-plist --help`.
 
 #### `--package-paths`
 
-- Support for multiple `Pakckage.swift`
+- Support for multiple `Package.swift`
 - Example: `license-plist --package-paths /path/to/package1/Package.swift /path/to/package2/Package.swift`
 
 #### `--xcodeproj-path`


### PR DESCRIPTION
I added explanation to `Readme.md` as I have to look at #157 to find out the options when using multiple `Package.swift`.
