### PR TITLE
Improve Naming for Swift Packages using Package.resolved v2

### DIFF
--- a/Sources/LicensePlistCore/Entity/Config.swift
+++ b/Sources/LicensePlistCore/Entity/Config.swift
@@ -94,10 +94,8 @@ public struct Config {
     }
 
     func excluded(name: String) -> Bool {
-        for exclude in excludes {
-            if matches(testString: name, matchString: exclude.name) {
-                return true
-            }
+        for exclude in excludes where matches(testString: name, matchString: exclude.name) {
+            return true
         }
         return false
     }

--- a/Sources/LicensePlistCore/Entity/SwiftPackage.swift
+++ b/Sources/LicensePlistCore/Entity/SwiftPackage.swift
@@ -12,6 +12,7 @@ public struct SwiftPackage: Equatable {
     let repositoryURL: String
     let revision: String?
     let version: String?
+    let packageDefinitionVersion: Int
 }
 
 struct SwiftPackageV1: Decodable {
@@ -57,11 +58,11 @@ extension SwiftPackage {
         guard let data = content.data(using: .utf8) else { return [] }
         if let resolvedPackagesV1 = try? JSONDecoder().decode(ResolvedPackagesV1.self, from: data) {
             return resolvedPackagesV1.object.pins.map {
-                SwiftPackage(package: $0.package, repositoryURL: $0.repositoryURL, revision: $0.state.revision, version: $0.state.version)
+                SwiftPackage(package: $0.package, repositoryURL: $0.repositoryURL, revision: $0.state.revision, version: $0.state.version, packageDefinitionVersion: 1)
             }
         } else if let resolvedPackagesV2 = try? JSONDecoder().decode(ResolvedPackagesV2.self, from: data) {
             return resolvedPackagesV2.pins.map {
-                SwiftPackage(package: $0.identity, repositoryURL: $0.location, revision: $0.state.revision, version: $0.state.version)
+                SwiftPackage(package: $0.identity, repositoryURL: $0.location, revision: $0.state.revision, version: $0.state.version, packageDefinitionVersion: 2)
             }
         } else {
             return []
@@ -85,8 +86,79 @@ extension SwiftPackage {
         }
 
         return GitHub(name: name,
-                      nameSpecified: renames[name] ?? package,
+                      nameSpecified: renames[name] ?? getDefaultName(for: owner, and: name),
                       owner: owner,
                       version: version)
     }
+    
+    private func getDefaultName(for owner: String, and name: String) -> String {
+        guard packageDefinitionVersion != 1 else { return package } // In SPM v1 the Package.resolved JSON always contains the correct name, no need for anything else.
+        guard let version = version else { return fallbackName(using: name) }
+        guard let packageDefinitionURL = URL(string: "https://raw.githubusercontent.com/\(owner)/\(name)/\(version)/Package.swift") else { return fallbackName(using: name) }
+        guard let packageDefinition = try? String(contentsOf: packageDefinitionURL) else { return fallbackName(using: name) }
+        return parseName(from: packageDefinition) ?? fallbackName(using: name)
+    }
+    
+    private func fallbackName(using githubName: String) -> String {
+        packageDefinitionVersion == 1 ? package : githubName
+    }
+    
+    func parseName(from packageDefinition: String) -> String? {
+        // Step 1 - Trim the beginning of the Package Description to where the Package object is starting to be defined -> return as a one-liner without spaces
+        let startingPoint = packageDefinition
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .components(separatedBy: "let package = Package")[1]
+        
+        // Step 2 - Assemble Reduced Package Description
+        // This removes all nested square brackets and everything written after the closing round bracket of the Package definition
+        var nestingRoundBracketsCounter = 0
+        var nestingSquareBracketsCounter = 0
+        var reducedPackageDescription = ""
+        
+        parsing: for character in startingPoint {
+            switch character {
+            case "(":
+                nestingRoundBracketsCounter += 1
+                reducedPackageDescription.append(nestingSquareBracketsCounter == 0 ? "\(character)" : "")
+                
+            case ")":
+                nestingRoundBracketsCounter -= 1
+                reducedPackageDescription.append(nestingSquareBracketsCounter == 0 ? "\(character)" : "")
+                if nestingRoundBracketsCounter < 1 {
+                    break parsing
+                }
+                
+            case "[":
+                nestingSquareBracketsCounter += 1
+                
+            case "]":
+                nestingSquareBracketsCounter -= 1
+                
+            default:
+                reducedPackageDescription.append(nestingSquareBracketsCounter == 0 ? "\(character)" : "")
+            }
+        }
+        
+        // Step 3 - Retrieve name from the reduced Package Description
+        // We can now be confident that we only have the top level description which has exactly one name.
+        
+        let name = reducedPackageDescription
+            .replacingOccurrences(of: "name\\s?:\\s?\"", with: "name:\"", options: .regularExpression)
+            .components(separatedBy: "name:\"")
+            .element(at: 1)
+            .components(separatedBy: "\"")
+            .element(at: 0)
+        
+        return name.isEmpty ? nil : name
+    }
+    
+}
+
+extension Array where Element == String {
+    
+    func element(at index: Int) -> String {
+        guard (0 ..< count).contains(index) else { return "" }
+        return String(self[index])
+    }
+    
 }

--- a/Sources/LicensePlistCore/Entity/SwiftPackage.swift
+++ b/Sources/LicensePlistCore/Entity/SwiftPackage.swift
@@ -90,7 +90,7 @@ extension SwiftPackage {
                       owner: owner,
                       version: version)
     }
-    
+
     private func getDefaultName(for owner: String, and name: String) -> String {
         guard packageDefinitionVersion != 1 else { return package } // In SPM v1 the Package.resolved JSON always contains the correct name, no need for anything else.
         guard let version = version else { return fallbackName(using: name) }
@@ -98,67 +98,67 @@ extension SwiftPackage {
         guard let packageDefinition = try? String(contentsOf: packageDefinitionURL) else { return fallbackName(using: name) }
         return parseName(from: packageDefinition) ?? fallbackName(using: name)
     }
-    
+
     private func fallbackName(using githubName: String) -> String {
         packageDefinitionVersion == 1 ? package : githubName
     }
-    
+
     func parseName(from packageDefinition: String) -> String? {
         // Step 1 - Trim the beginning of the Package Description to where the Package object is starting to be defined -> return as a one-liner without spaces
         let startingPoint = packageDefinition
             .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
             .components(separatedBy: "let package = Package")[1]
-        
+
         // Step 2 - Assemble Reduced Package Description
         // This removes all nested square brackets and everything written after the closing round bracket of the Package definition
         var nestingRoundBracketsCounter = 0
         var nestingSquareBracketsCounter = 0
         var reducedPackageDescription = ""
-        
+
         parsing: for character in startingPoint {
             switch character {
             case "(":
                 nestingRoundBracketsCounter += 1
                 reducedPackageDescription.append(nestingSquareBracketsCounter == 0 ? "\(character)" : "")
-                
+
             case ")":
                 nestingRoundBracketsCounter -= 1
                 reducedPackageDescription.append(nestingSquareBracketsCounter == 0 ? "\(character)" : "")
                 if nestingRoundBracketsCounter < 1 {
                     break parsing
                 }
-                
+
             case "[":
                 nestingSquareBracketsCounter += 1
-                
+
             case "]":
                 nestingSquareBracketsCounter -= 1
-                
+
             default:
                 reducedPackageDescription.append(nestingSquareBracketsCounter == 0 ? "\(character)" : "")
             }
         }
-        
+
         // Step 3 - Retrieve name from the reduced Package Description
         // We can now be confident that we only have the top level description which has exactly one name.
-        
+
         let name = reducedPackageDescription
             .replacingOccurrences(of: "name\\s?:\\s?\"", with: "name:\"", options: .regularExpression)
             .components(separatedBy: "name:\"")
             .element(at: 1)
             .components(separatedBy: "\"")
             .element(at: 0)
-        
+
         return name.isEmpty ? nil : name
     }
-    
+
 }
 
 extension Array where Element == String {
-    
+
     func element(at index: Int) -> String {
         guard (0 ..< count).contains(index) else { return "" }
         return String(self[index])
     }
-    
+
 }

--- a/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
+++ b/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
@@ -10,6 +10,9 @@ import XCTest
 @testable import LicensePlistCore
 
 class SwiftPackageManagerTests: XCTestCase {
+    
+    // MARK: - SPM v1
+    
     func testDecodingV1() throws {
         let jsonString = """
             {
@@ -76,6 +79,107 @@ class SwiftPackageManagerTests: XCTestCase {
         XCTAssertEqual(package.state.branch, "master")
         XCTAssertNil(package.state.version)
     }
+    
+    func testConvertToGithub() {
+        let package = SwiftPackage(package: "Commander",
+                                   repositoryURL: "https://github.com/kylef/Commander.git",
+                                   revision: "e5b50ad7b2e91eeb828393e89b03577b16be7db9",
+                                   version: "0.8.0",
+                                   packageDefinitionVersion: 1)
+        let result = package.toGitHub(renames: [:])
+        XCTAssertEqual(result, GitHub(name: "Commander", nameSpecified: "Commander", owner: "kylef", version: "0.8.0"))
+    }
+    
+    func testConvertToGithubNameWithDots() {
+        let package = SwiftPackage(package: "R.swift.Library",
+                                   repositoryURL: "https://github.com/mac-cain13/R.swift.Library",
+                                   revision: "3365947d725398694d6ed49f2e6622f05ca3fc0f",
+                                   version: nil,
+                                   packageDefinitionVersion: 1)
+        let result = package.toGitHub(renames: [:])
+        XCTAssertEqual(result, GitHub(name: "R.swift.Library", nameSpecified: "R.swift.Library", owner: "mac-cain13", version: nil))
+    }
+    
+    func testConvertToGithubSSH() {
+        let package = SwiftPackage(package: "LicensePlist",
+                                   repositoryURL: "git@github.com:mono0926/LicensePlist.git",
+                                   revision: "3365947d725398694d6ed49f2e6622f05ca3fc0e",
+                                   version: nil,
+                                   packageDefinitionVersion: 1)
+        let result = package.toGitHub(renames: [:])
+        XCTAssertEqual(result, GitHub(name: "LicensePlist", nameSpecified: "LicensePlist", owner: "mono0926", version: nil))
+    }
+    
+    func testConvertToGithubPackageName() {
+        let package = SwiftPackage(package: "IterableSDK",
+                                   repositoryURL: "https://github.com/Iterable/swift-sdk",
+                                   revision: "3365947d725398694d6ed49f2e6622f05ca3fc0e",
+                                   version: nil,
+                                   packageDefinitionVersion: 1)
+        let result = package.toGitHub(renames: [:])
+        XCTAssertEqual(result, GitHub(name: "swift-sdk", nameSpecified: "IterableSDK", owner: "Iterable", version: nil))
+    }
+    
+    func testConvertToGithubRenames() {
+        let package = SwiftPackage(package: "IterableSDK",
+                                   repositoryURL: "https://github.com/Iterable/swift-sdk",
+                                   revision: "3365947d725398694d6ed49f2e6622f05ca3fc0e",
+                                   version: nil,
+                                   packageDefinitionVersion: 1)
+        let result = package.toGitHub(renames: ["swift-sdk": "NAME"])
+        XCTAssertEqual(result, GitHub(name: "swift-sdk", nameSpecified: "NAME", owner: "Iterable", version: nil))
+    }
+    
+    func testRename() {
+        let package = SwiftPackage(package: "Commander",
+                                   repositoryURL: "https://github.com/kylef/Commander.git",
+                                   revision: "e5b50ad7b2e91eeb828393e89b03577b16be7db9",
+                                   version: "0.8.0",
+                                   packageDefinitionVersion: 1)
+        let result = package.toGitHub(renames: ["Commander": "RenamedCommander"])
+        XCTAssertEqual(result, GitHub(name: "Commander", nameSpecified: "RenamedCommander", owner: "kylef", version: "0.8.0"))
+    }
+    
+    func testInvalidURL() {
+        let package = SwiftPackage(package: "Google", repositoryURL: "http://www.google.com", revision: "", version: "0.0.0", packageDefinitionVersion: 1)
+        let result = package.toGitHub(renames: [:])
+        XCTAssertNil(result)
+    }
+    
+    func testNonGithub() {
+        let package = SwiftPackage(package: "Bitbucket",
+                                   repositoryURL: "https://mbuchetics@bitbucket.org/mbuchetics/adventofcode2018.git",
+                                   revision: "",
+                                   version: "0.0.0",
+                                   packageDefinitionVersion: 1)
+        let result = package.toGitHub(renames: [:])
+        XCTAssertNil(result)
+    }
+    
+    func testParse() throws {
+        let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Package.resolved"
+        let content = try String(contentsOf: XCTUnwrap(URL(string: path)))
+        let packages = SwiftPackage.loadPackages(content)
+        
+        XCTAssertFalse(packages.isEmpty)
+        XCTAssertEqual(packages.count, 7)
+        
+        let packageFirst = try XCTUnwrap(packages.first)
+        XCTAssertEqual(packageFirst, SwiftPackage(package: "APIKit",
+                                                  repositoryURL: "https://github.com/ishkawa/APIKit.git",
+                                                  revision: "4e7f42d93afb787b0bc502171f9b5c12cf49d0ca",
+                                                  version: "5.3.0",
+                                                  packageDefinitionVersion: 1))
+        let packageLast = try XCTUnwrap(packages.last)
+        XCTAssertEqual(packageLast, SwiftPackage(package: "Yaml",
+                                                 repositoryURL: "https://github.com/behrang/YamlSwift.git",
+                                                 revision: "287f5cab7da0d92eb947b5fd8151b203ae04a9a3",
+                                                 version: "3.4.4",
+                                                 packageDefinitionVersion: 1))
+        
+    }
+    
+    // MARK: - SPM v2
 
     func testDecodingWithVersionV2() throws {
         let jsonString = """
@@ -122,94 +226,206 @@ class SwiftPackageManagerTests: XCTestCase {
         XCTAssertEqual(package.state.branch, "master")
         XCTAssertNil(package.state.version)
     }
-
-    func testConvertToGithub() {
-        let package = SwiftPackage(package: "Commander",
-                                   repositoryURL: "https://github.com/kylef/Commander.git",
-                                   revision: "e5b50ad7b2e91eeb828393e89b03577b16be7db9",
-                                   version: "0.8.0")
+    
+    // MARK: SPM v2 Name Parsing
+    
+    private let testPackage = SwiftPackage(package: "Unit Test Fake", repositoryURL: "https://github.com/unit/test", revision: nil, version: nil, packageDefinitionVersion: 2)
+    
+    func testNameParsingStandardV2() throws {
+        let packageSwiftString = """
+        // swift-tools-version:5.0
+        // The swift-tools-version declares the minimum version of Swift required to build this package.
+        
+        import PackageDescription
+        
+        let package = Package(
+            name: "Valet",
+            platforms: [
+                .iOS(.v9),
+                .tvOS(.v9),
+                .watchOS(.v2),
+                .macOS(.v10_11),
+            ],
+            products: [
+                .library(
+                    name: "Valet",
+                    targets: ["Valet"]),
+            ],
+            targets: [
+                .target(
+                name: "Valet",
+                dependencies: []),
+            ],
+            swiftLanguageVersions: [.v5]
+        )
+        """
+        
+        XCTAssertEqual(testPackage.parseName(from: packageSwiftString), "Valet")
+    }
+    
+    func testNameParsingWithCommentsV2() throws {
+        let packageSwiftString = """
+        // swift-tools-version:5.6
+        //
+        //  Package.swift
+        //
+        //  Copyright (c) 2014-2020 Alamofire Software Foundation (http://alamofire.org/)
+        //
+        //  Permission is hereby granted, free of charge, to any person obtaining a copy
+        //  of this software and associated documentation files (the "Software"), to deal
+        //  in the Software without restriction, including without limitation the rights
+        //  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        //  copies of the Software, and to permit persons to whom the Software is
+        //  furnished to do so, subject to the following conditions:
+        //
+        //  The above copyright notice and this permission notice shall be included in
+        //  all copies or substantial portions of the Software.
+        //
+        //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        //  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        //  THE SOFTWARE.
+        //
+        
+        import PackageDescription
+        
+        let package = Package(name: "Alamofire",
+                      platforms: [.macOS(.v10_12),
+                                  .iOS(.v10),
+                                  .tvOS(.v10),
+                                  .watchOS(.v3)],
+                      products: [.library(name: "Alamofire",
+                                          targets: ["Alamofire"])],
+                      targets: [.target(name: "Alamofire",
+                                        path: "Source",
+                                        exclude: ["Info.plist"],
+                                        linkerSettings: [.linkedFramework("CFNetwork",
+                                                                          .when(platforms: [.iOS,
+                                                                                            .macOS,
+                                                                                            .tvOS,
+                                                                                            .watchOS]))]),
+                                .testTarget(name: "AlamofireTests",
+                                            dependencies: ["Alamofire"],
+                                            path: "Tests",
+                                            exclude: ["Info.plist", "Test Plans"],
+                                            resources: [.process("Resources")])],
+                      swiftLanguageVersions: [.v5])
+        """
+        
+        XCTAssertEqual(testPackage.parseName(from: packageSwiftString), "Alamofire")
+    }
+    
+    func testNameParsingNonStandardV2() throws {
+        let packageSwiftString = """
+        // swift-tools-version: 5.6
+        // The swift-tools-version declares the minimum version of Swift required to build this package.
+        
+        import PackageDescription
+        
+        private let prettyLog = "PrettyLog"
+        
+        let package = Package(
+            name: prettyLog,
+            platforms: [
+                .iOS(.v11),
+                .macCatalyst(.v13),
+                .macOS(.v10_13),
+                .tvOS(.v11),
+                .watchOS(.v4)
+            ],
+            products: [
+                .library(name: prettyLog, targets: [prettyLog])
+            ],
+            targets: [
+                .target(name: prettyLog, dependencies: [])
+            ]
+        )
+        """
+        
+        XCTAssertEqual(testPackage.parseName(from: packageSwiftString), nil, "This should be `nil` because the name is not defined as a String. Which is still valid SPM but sadly not easily parseable. We need to fall back to other methods for getting the name.")
+    }
+    
+    func testNameParsingWithAdditionalCodeInPackageDefinitionV2() throws {
+        let packageSwiftString = """
+        // swift-tools-version: 5.6
+        // The swift-tools-version declares the minimum version of Swift required to build this package.
+        
+        import PackageDescription
+        
+        let someOtherPackageThatWeDontNeed = Package(
+            name: "This should not be parsed",
+            platforms: [
+                .macOS(.v10_12),
+                .iOS(.v10),
+                .tvOS(.v10),
+                .watchOS(.v3)],
+            products: [
+                .library(
+                    name: ""This should not be parsed",
+                    targets: [""This should not be parsed"])],
+            targets: [
+                .target(
+                    name: ""This should not be parsed",
+                    path: "Source",
+                    exclude: ["Info.plist"],
+                    linkerSettings: [
+                        .linkedFramework("CFNetwork", .when(platforms: [.iOS, .macOS, .tvOS, .watchOS]))]),
+                .testTarget(
+                    name: ""This should not be parsed Tests",
+                    dependencies: [""This should not be parsed"],
+                    path: "Tests",
+                    exclude: ["Info.plist", "Test Plans"],
+                    resources: [.process("Resources")])],
+            swiftLanguageVersions: [.v5])
+        
+        let everythingAbove = "should not be parsed!"
+        
+        let package = Package(
+            name: "SUCCESS",
+            platforms: [
+                .macOS(.v10_12),
+                .iOS(.v10),
+                .tvOS(.v10),
+                .watchOS(.v3)],
+            products: [
+                .library(
+                    name: "SUCCESS",
+                    targets: ["SUCCESS"])],
+            targets: [
+                .target(
+                    name: "SUCCESS",
+                    path: "Source",
+                    exclude: ["Info.plist"],
+                    linkerSettings: [
+                        .linkedFramework("CFNetwork", .when(platforms: [.iOS, .macOS, .tvOS, .watchOS]))]),
+                .testTarget(
+                    name: "SUCCESSTests",
+                    dependencies: ["SUCCESS"],
+                    path: "Tests",
+                    exclude: ["Info.plist", "Test Plans"],
+                    resources: [.process("Resources")])],
+            swiftLanguageVersions: [.v5])
+        
+        let everythingBelow = "should not be parsed!"
+        
+        let oneMoreUninterestingPackage = Package(
+            name: "Not interesting to us")
+        """
+        
+        XCTAssertEqual(testPackage.parseName(from: packageSwiftString), "SUCCESS", "This should be `SUCCESS` because we only need to look at the Package object stored in the constant `let package`.")
+    }
+    
+    func testConvertToGithubPackageNameV2() {
+        let package = SwiftPackage(package: "SPM v2 Name automattically written in lowercase",
+                                   repositoryURL: "https://github.com/test/better-name-parsed-from-repo",
+                                   revision: nil,
+                                   version: nil,
+                                   packageDefinitionVersion: 2)
         let result = package.toGitHub(renames: [:])
-        XCTAssertEqual(result, GitHub(name: "Commander", nameSpecified: "Commander", owner: "kylef", version: "0.8.0"))
+        XCTAssertEqual(result?.nameSpecified, "better-name-parsed-from-repo", "For SPM v2 we try to parse the Package.swift from the repository to get the name. But when that fails, we fall back to the name in the Repository URL which is still an improvement to the name we get as `identity` from the generated JSON.")
     }
-
-    func testConvertToGithubNameWithDots() {
-        let package = SwiftPackage(package: "R.swift.Library",
-                                   repositoryURL: "https://github.com/mac-cain13/R.swift.Library",
-                                   revision: "3365947d725398694d6ed49f2e6622f05ca3fc0f",
-                                   version: nil)
-        let result = package.toGitHub(renames: [:])
-        XCTAssertEqual(result, GitHub(name: "R.swift.Library", nameSpecified: "R.swift.Library", owner: "mac-cain13", version: nil))
-    }
-
-    func testConvertToGithubSSH() {
-        let package = SwiftPackage(package: "LicensePlist",
-                                   repositoryURL: "git@github.com:mono0926/LicensePlist.git",
-                                   revision: "3365947d725398694d6ed49f2e6622f05ca3fc0e",
-                                   version: nil)
-        let result = package.toGitHub(renames: [:])
-        XCTAssertEqual(result, GitHub(name: "LicensePlist", nameSpecified: "LicensePlist", owner: "mono0926", version: nil))
-    }
-
-    func testConvertToGithubPackageName() {
-        let package = SwiftPackage(package: "IterableSDK",
-                                   repositoryURL: "https://github.com/Iterable/swift-sdk",
-                                   revision: "3365947d725398694d6ed49f2e6622f05ca3fc0e",
-                                   version: nil)
-        let result = package.toGitHub(renames: [:])
-        XCTAssertEqual(result, GitHub(name: "swift-sdk", nameSpecified: "IterableSDK", owner: "Iterable", version: nil))
-    }
-
-    func testConvertToGithubRenames() {
-        let package = SwiftPackage(package: "IterableSDK",
-                                   repositoryURL: "https://github.com/Iterable/swift-sdk",
-                                   revision: "3365947d725398694d6ed49f2e6622f05ca3fc0e",
-                                   version: nil)
-        let result = package.toGitHub(renames: ["swift-sdk": "NAME"])
-        XCTAssertEqual(result, GitHub(name: "swift-sdk", nameSpecified: "NAME", owner: "Iterable", version: nil))
-    }
-
-    func testRename() {
-        let package = SwiftPackage(package: "Commander",
-                                   repositoryURL: "https://github.com/kylef/Commander.git",
-                                   revision: "e5b50ad7b2e91eeb828393e89b03577b16be7db9",
-                                   version: "0.8.0")
-        let result = package.toGitHub(renames: ["Commander": "RenamedCommander"])
-        XCTAssertEqual(result, GitHub(name: "Commander", nameSpecified: "RenamedCommander", owner: "kylef", version: "0.8.0"))
-    }
-
-    func testInvalidURL() {
-        let package = SwiftPackage(package: "Google", repositoryURL: "http://www.google.com", revision: "", version: "0.0.0")
-        let result = package.toGitHub(renames: [:])
-        XCTAssertNil(result)
-    }
-
-    func testNonGithub() {
-        let package = SwiftPackage(package: "Bitbucket",
-                                   repositoryURL: "https://mbuchetics@bitbucket.org/mbuchetics/adventofcode2018.git",
-                                   revision: "",
-                                   version: "0.0.0")
-        let result = package.toGitHub(renames: [:])
-        XCTAssertNil(result)
-    }
-
-    func testParse() throws {
-        let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Package.resolved"
-        let content = try String(contentsOf: XCTUnwrap(URL(string: path)))
-        let packages = SwiftPackage.loadPackages(content)
-
-        XCTAssertFalse(packages.isEmpty)
-        XCTAssertEqual(packages.count, 7)
-
-        let packageFirst = try XCTUnwrap(packages.first)
-        XCTAssertEqual(packageFirst, SwiftPackage(package: "APIKit",
-                                                  repositoryURL: "https://github.com/ishkawa/APIKit.git",
-                                                  revision: "4e7f42d93afb787b0bc502171f9b5c12cf49d0ca",
-                                                  version: "5.3.0"))
-        let packageLast = try XCTUnwrap(packages.last)
-        XCTAssertEqual(packageLast, SwiftPackage(package: "Yaml",
-                                                 repositoryURL: "https://github.com/behrang/YamlSwift.git",
-                                                 revision: "287f5cab7da0d92eb947b5fd8151b203ae04a9a3",
-                                                 version: "3.4.4"))
-
-    }
+    
 }

--- a/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
+++ b/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
@@ -5,14 +5,20 @@
 //  Created by Matthias Buchetics on 20.09.19.
 //
 
+// swiftlint:disable file_length type_body_length function_body_length line_length
+// Disabling file length warnings from SwiftLint, because any meaningful test should be included in the Test Suite
+// Disabling type body length warnings from SwiftLint for the same reason as file length
+// Disabling function body length warnings from SwiftLint, because Unit Tests may contain longer mock and fake definitions that should not be refactored
+// Disabling line length warnings from SwiftLint, because writing in depth explanations for failing tests is favorable
+
 import Foundation
 import XCTest
 @testable import LicensePlistCore
 
 class SwiftPackageManagerTests: XCTestCase {
-    
+
     // MARK: - SPM v1
-    
+
     func testDecodingV1() throws {
         let jsonString = """
             {
@@ -79,7 +85,7 @@ class SwiftPackageManagerTests: XCTestCase {
         XCTAssertEqual(package.state.branch, "master")
         XCTAssertNil(package.state.version)
     }
-    
+
     func testConvertToGithub() {
         let package = SwiftPackage(package: "Commander",
                                    repositoryURL: "https://github.com/kylef/Commander.git",
@@ -89,7 +95,7 @@ class SwiftPackageManagerTests: XCTestCase {
         let result = package.toGitHub(renames: [:])
         XCTAssertEqual(result, GitHub(name: "Commander", nameSpecified: "Commander", owner: "kylef", version: "0.8.0"))
     }
-    
+
     func testConvertToGithubNameWithDots() {
         let package = SwiftPackage(package: "R.swift.Library",
                                    repositoryURL: "https://github.com/mac-cain13/R.swift.Library",
@@ -99,7 +105,7 @@ class SwiftPackageManagerTests: XCTestCase {
         let result = package.toGitHub(renames: [:])
         XCTAssertEqual(result, GitHub(name: "R.swift.Library", nameSpecified: "R.swift.Library", owner: "mac-cain13", version: nil))
     }
-    
+
     func testConvertToGithubSSH() {
         let package = SwiftPackage(package: "LicensePlist",
                                    repositoryURL: "git@github.com:mono0926/LicensePlist.git",
@@ -109,7 +115,7 @@ class SwiftPackageManagerTests: XCTestCase {
         let result = package.toGitHub(renames: [:])
         XCTAssertEqual(result, GitHub(name: "LicensePlist", nameSpecified: "LicensePlist", owner: "mono0926", version: nil))
     }
-    
+
     func testConvertToGithubPackageName() {
         let package = SwiftPackage(package: "IterableSDK",
                                    repositoryURL: "https://github.com/Iterable/swift-sdk",
@@ -119,7 +125,7 @@ class SwiftPackageManagerTests: XCTestCase {
         let result = package.toGitHub(renames: [:])
         XCTAssertEqual(result, GitHub(name: "swift-sdk", nameSpecified: "IterableSDK", owner: "Iterable", version: nil))
     }
-    
+
     func testConvertToGithubRenames() {
         let package = SwiftPackage(package: "IterableSDK",
                                    repositoryURL: "https://github.com/Iterable/swift-sdk",
@@ -129,7 +135,7 @@ class SwiftPackageManagerTests: XCTestCase {
         let result = package.toGitHub(renames: ["swift-sdk": "NAME"])
         XCTAssertEqual(result, GitHub(name: "swift-sdk", nameSpecified: "NAME", owner: "Iterable", version: nil))
     }
-    
+
     func testRename() {
         let package = SwiftPackage(package: "Commander",
                                    repositoryURL: "https://github.com/kylef/Commander.git",
@@ -139,13 +145,13 @@ class SwiftPackageManagerTests: XCTestCase {
         let result = package.toGitHub(renames: ["Commander": "RenamedCommander"])
         XCTAssertEqual(result, GitHub(name: "Commander", nameSpecified: "RenamedCommander", owner: "kylef", version: "0.8.0"))
     }
-    
+
     func testInvalidURL() {
         let package = SwiftPackage(package: "Google", repositoryURL: "http://www.google.com", revision: "", version: "0.0.0", packageDefinitionVersion: 1)
         let result = package.toGitHub(renames: [:])
         XCTAssertNil(result)
     }
-    
+
     func testNonGithub() {
         let package = SwiftPackage(package: "Bitbucket",
                                    repositoryURL: "https://mbuchetics@bitbucket.org/mbuchetics/adventofcode2018.git",
@@ -155,15 +161,15 @@ class SwiftPackageManagerTests: XCTestCase {
         let result = package.toGitHub(renames: [:])
         XCTAssertNil(result)
     }
-    
+
     func testParse() throws {
         let path = "https://raw.githubusercontent.com/mono0926/LicensePlist/master/Package.resolved"
         let content = try String(contentsOf: XCTUnwrap(URL(string: path)))
         let packages = SwiftPackage.loadPackages(content)
-        
+
         XCTAssertFalse(packages.isEmpty)
         XCTAssertEqual(packages.count, 7)
-        
+
         let packageFirst = try XCTUnwrap(packages.first)
         XCTAssertEqual(packageFirst, SwiftPackage(package: "APIKit",
                                                   repositoryURL: "https://github.com/ishkawa/APIKit.git",
@@ -176,9 +182,9 @@ class SwiftPackageManagerTests: XCTestCase {
                                                  revision: "287f5cab7da0d92eb947b5fd8151b203ae04a9a3",
                                                  version: "3.4.4",
                                                  packageDefinitionVersion: 1))
-        
+
     }
-    
+
     // MARK: - SPM v2
 
     func testDecodingWithVersionV2() throws {
@@ -226,18 +232,18 @@ class SwiftPackageManagerTests: XCTestCase {
         XCTAssertEqual(package.state.branch, "master")
         XCTAssertNil(package.state.version)
     }
-    
+
     // MARK: SPM v2 Name Parsing
-    
+
     private let testPackage = SwiftPackage(package: "Unit Test Fake", repositoryURL: "https://github.com/unit/test", revision: nil, version: nil, packageDefinitionVersion: 2)
-    
+
     func testNameParsingStandardV2() throws {
         let packageSwiftString = """
         // swift-tools-version:5.0
         // The swift-tools-version declares the minimum version of Swift required to build this package.
-        
+
         import PackageDescription
-        
+
         let package = Package(
             name: "Valet",
             platforms: [
@@ -259,10 +265,10 @@ class SwiftPackageManagerTests: XCTestCase {
             swiftLanguageVersions: [.v5]
         )
         """
-        
+
         XCTAssertEqual(testPackage.parseName(from: packageSwiftString), "Valet")
     }
-    
+
     func testNameParsingWithCommentsV2() throws {
         let packageSwiftString = """
         // swift-tools-version:5.6
@@ -289,9 +295,9 @@ class SwiftPackageManagerTests: XCTestCase {
         //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
         //  THE SOFTWARE.
         //
-        
+
         import PackageDescription
-        
+
         let package = Package(name: "Alamofire",
                       platforms: [.macOS(.v10_12),
                                   .iOS(.v10),
@@ -314,19 +320,19 @@ class SwiftPackageManagerTests: XCTestCase {
                                             resources: [.process("Resources")])],
                       swiftLanguageVersions: [.v5])
         """
-        
+
         XCTAssertEqual(testPackage.parseName(from: packageSwiftString), "Alamofire")
     }
-    
+
     func testNameParsingNonStandardV2() throws {
         let packageSwiftString = """
         // swift-tools-version: 5.6
         // The swift-tools-version declares the minimum version of Swift required to build this package.
-        
+
         import PackageDescription
-        
+
         private let prettyLog = "PrettyLog"
-        
+
         let package = Package(
             name: prettyLog,
             platforms: [
@@ -344,17 +350,17 @@ class SwiftPackageManagerTests: XCTestCase {
             ]
         )
         """
-        
+
         XCTAssertEqual(testPackage.parseName(from: packageSwiftString), nil, "This should be `nil` because the name is not defined as a String. Which is still valid SPM but sadly not easily parseable. We need to fall back to other methods for getting the name.")
     }
-    
+
     func testNameParsingWithAdditionalCodeInPackageDefinitionV2() throws {
         let packageSwiftString = """
         // swift-tools-version: 5.6
         // The swift-tools-version declares the minimum version of Swift required to build this package.
-        
+
         import PackageDescription
-        
+
         let someOtherPackageThatWeDontNeed = Package(
             name: "This should not be parsed",
             platforms: [
@@ -380,9 +386,9 @@ class SwiftPackageManagerTests: XCTestCase {
                     exclude: ["Info.plist", "Test Plans"],
                     resources: [.process("Resources")])],
             swiftLanguageVersions: [.v5])
-        
+
         let everythingAbove = "should not be parsed!"
-        
+
         let package = Package(
             name: "SUCCESS",
             platforms: [
@@ -408,16 +414,16 @@ class SwiftPackageManagerTests: XCTestCase {
                     exclude: ["Info.plist", "Test Plans"],
                     resources: [.process("Resources")])],
             swiftLanguageVersions: [.v5])
-        
+
         let everythingBelow = "should not be parsed!"
-        
+
         let oneMoreUninterestingPackage = Package(
             name: "Not interesting to us")
         """
-        
+
         XCTAssertEqual(testPackage.parseName(from: packageSwiftString), "SUCCESS", "This should be `SUCCESS` because we only need to look at the Package object stored in the constant `let package`.")
     }
-    
+
     func testConvertToGithubPackageNameV2() {
         let package = SwiftPackage(package: "SPM v2 Name automattically written in lowercase",
                                    repositoryURL: "https://github.com/test/better-name-parsed-from-repo",
@@ -427,5 +433,5 @@ class SwiftPackageManagerTests: XCTestCase {
         let result = package.toGitHub(renames: [:])
         XCTAssertEqual(result?.nameSpecified, "better-name-parsed-from-repo", "For SPM v2 we try to parse the Package.swift from the repository to get the name. But when that fails, we fall back to the name in the Repository URL which is still an improvement to the name we get as `identity` from the generated JSON.")
     }
-    
+
 }


### PR DESCRIPTION
### Problem (Issue #179)

> With the new Package.resolved JSON version 2 (https://github.com/mono0926/LicensePlist/pull/174), which Apple introduce with Xcode 13.3 and Swift 5.6, I miss the correct package names.

### Attempted Solution

Based on the idea of @ykws:

> We may be able to pick up the name from [Package(name:) in Package.swift](https://github.com/microsoft/appcenter-sdk-apple/blob/a52cb5001c94e86a04bee0ce8d9fc1a73ccf2985/Package.swift#L54), we can access each location in Package.resolved as repository url.

This PR has a solution that works in most cases by doing exactly that and falls back to a sensible default name when parsing the `Package.swift` fails.

### In depth

What I implement here is a 3-step process to get the best name possible from the new version of Package.resolved:

1. Make sure we don't parse a `Package.resolved` v1 file and instantly return the name from that otherwise (current v1 implementation)
2. Take the Repository Name from the Github Conversion Step that is currently implemented in LicensePlist which is already an improvement on the result of Step 1 (current v2 implementation), since it has uppercased characters in all the right places. We still have some issues when dealing with Packages containing spaces though (those have dashes instead, but replacing those would break Packages that really have dashes in their names).
3. Parse the `Package.swift` from the Repository by looking for the first `Package` object, removing all nested code inside `[...]` to eliminate dependency and target names and finally getting the remaining value for `name`. If anything fails we return `nil` which lets us fall back to the result of Step 2.

Edge cases I encountered are also added as Unit Tests, so you can play around in the parser with confidence.