### PR TITLE
swift-argument-parser 1.0.3 for official Homebrew support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "82905286cc3f0fa8adc4674bf49437cab65a8373",
-          "version": "1.1.1"
+          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+          "version": "1.0.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git",
-                 from: "1.1.1"),
+                 from: "1.0.3"),
         .package(url: "https://github.com/ishkawa/APIKit.git",
                  from: "5.3.0"),
         .package(url: "https://github.com/Kitura/HeliumLogger.git",

--- a/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
@@ -49,8 +49,8 @@ class SwiftPackageFileReaderTests: XCTestCase {
                 "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
                 "state": {
                   "branch": null,
-                  "revision": "82905286cc3f0fa8adc4674bf49437cab65a8373",
-                  "version": "1.1.1"
+                  "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+                  "version": "1.0.3"
                 }
               },
               {


### PR DESCRIPTION
[AsyncParsableCommand.swift](https://github.com/apple/swift-argument-parser/blob/1.1.4/Sources/ArgumentParser/Parsable%20Types/AsyncParsableCommand.swift) has breaking change against Big Sur and won't compile on Big Sur.
Homebrew project won't accept things which cannot build from source on Big Sur now and it seems that we don't need swift-argument-parser to be 1.1.1.

I suggest that downgrade swift-argument-parser to support wider OSes and we can achieve the adoption of Homebrew.