### PR TITLE
Prefer the Homebrew official formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,7 @@ pod 'LicensePlist'
 ### Homebrew (Also Recommended)
 
 ```sh
-brew install mono0926/license-plist/license-plist
-```
-
-Or
-
-```sh
-brew tap mono0926/license-plist
-brew install license-plist
+brew install licenseplist
 ```
 
 ### Mint (Also Recommended)


### PR DESCRIPTION
LicensePlist is now included on Homebrew and can be installed via `brew install licenseplist`.

I suggest that we prefer the Homebrew official formula.

Official Homebrew formula installs the pre-built binary so Homebrew users don't need to compile from the source.

Closes #56 
Closes #88 