### PR TITLE
Fix no name bug with trailing slash in URL

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,11 +8,13 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: Cyberbeni/install-swift-tool@v2
+      - name: Install SwiftLint
+        uses: Cyberbeni/install-swift-tool@v2
         with:
           url: https://github.com/realm/SwiftLint
-          version: '*'
-      - run: swiftlint lint --strict .
+          version: '0.46.5' # Workaround for https://github.com/realm/SwiftLint/issues/4031
+      - name: Lint (strict)
+        run: swiftlint lint --strict .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   lint:
+    # Follow https://github.com/Cyberbeni/install-swift-tool/blob/master/.github/workflows/test.yml#L9
     runs-on: ubuntu-20.04
+
     steps:
       - uses: actions/checkout@v2
       - name: Install SwiftLint

--- a/Sources/LicensePlistCore/Entity/SwiftPackage.swift
+++ b/Sources/LicensePlistCore/Entity/SwiftPackage.swift
@@ -75,13 +75,16 @@ extension SwiftPackage {
         let urlParts = repositoryURL
             .replacingOccurrences(of: "https://", with: "")
             .replacingOccurrences(of: "http://", with: "")
+            .deletingSuffix("/")
             .components(separatedBy: "/")
 
         let name = urlParts.last?.deletingSuffix(".git") ?? ""
         let owner: String
         if urlParts.count >= 3 {
+            // http/https
             owner = urlParts[urlParts.count - 2]
         } else {
+            // ssh
             owner = urlParts.first?.components(separatedBy: ":").last ?? ""
         }
 

--- a/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
+++ b/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
@@ -106,6 +106,16 @@ class SwiftPackageManagerTests: XCTestCase {
         XCTAssertEqual(result, GitHub(name: "R.swift.Library", nameSpecified: "R.swift.Library", owner: "mac-cain13", version: nil))
     }
 
+    func testConvertToGithubURLWithTrailingSlash() {
+        let package = SwiftPackage(package: "Defaults",
+                                   repositoryURL: "https://github.com/sindresorhus/Defaults/",
+                                   revision: "981ccb0a01c54abbe3c12ccb8226108527bbf115",
+                                   version: "6.3.0",
+                                   packageDefinitionVersion: 1)
+        let result = package.toGitHub(renames: [:])
+        XCTAssertEqual(result, GitHub(name: "Defaults", nameSpecified: "Defaults", owner: "sindresorhus", version: "6.3.0"))
+    }
+
     func testConvertToGithubSSH() {
         let package = SwiftPackage(package: "LicensePlist",
                                    repositoryURL: "git@github.com:mono0926/LicensePlist.git",


### PR DESCRIPTION
- Fixed: #159
- Added test: `SwiftPackageManagerTests.testConvertToGithubURLWithTrailingSlash`