### PR TITLE
Fix build tool plugin for Intel Macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ portable_zip: build_portable
 	(cd $(TEMPORARY_FOLDER); zip -r - LICENSE license-plist) > "./portable_licenseplist.zip"
 	rm -r "$(TEMPORARY_FOLDER)"
 
-spm_artifactbundle_macos: build
+spm_artifactbundle_macos: build_portable
 	mkdir -p "$(ARTIFACT_BUNDLE_PATH)/license-plist-$(VERSION_STRING)-macos/bin"
 	sed 's/__VERSION__/$(VERSION_STRING)/g' Tools/info-macos.json.template > "$(ARTIFACT_BUNDLE_PATH)/info.json"
-	cp -f ".build/release/license-plist" "$(ARTIFACT_BUNDLE_PATH)/license-plist-$(VERSION_STRING)-macos/bin"
+	cp -f ".build/apple/Products/Release/license-plist" "$(ARTIFACT_BUNDLE_PATH)/license-plist-$(VERSION_STRING)-macos/bin"
 	cp -f "$(LICENSE_PATH)" "$(ARTIFACT_BUNDLE_PATH)"
 	(cd "$(TEMPORARY_FOLDER)"; zip -yr - "LicensePlistBinary.artifactbundle") > "./LicensePlistBinary-macos.artifactbundle.zip"


### PR DESCRIPTION
# Description

On Intel Macs Xcode show "Bad CPU type in executable" error when running the SPM plugin. See issue #213.

# Analysis

The binary artifact in the latest release isn't a fat binary:

```
lipo -detailed_info ./bin/license-plist 
input file ./bin/license-plist is not a fat file
Non-fat file: ./bin/license-plist is architecture: arm64
```

The root cause of the issue is `spm_artifactbundle_macos` command in `Makefile`. It inherits `build` command. But `build` command produces binaries only for the current architecture.

# Solution

Use `build_portable` as a parent of `spm_artifactbundle_macos` command.