### PR TITLE
feature(yaml): replace yaml parser library to support multi new line

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -91,12 +91,12 @@
       }
     },
     {
-      "identity" : "yamlswift",
+      "identity" : "yams",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/behrang/YamlSwift.git",
+      "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "287f5cab7da0d92eb947b5fd8151b203ae04a9a3",
-        "version" : "3.4.4"
+        "revision" : "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
+        "version" : "5.0.5"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -18,14 +18,14 @@ let package = Package(
                  from: "5.3.0"),
         .package(url: "https://github.com/Kitura/HeliumLogger.git",
                  from: "2.0.0"),
-        .package(url: "https://github.com/behrang/YamlSwift.git",
-                 from: "3.4.4"),
         .package(url: "https://github.com/Kitura/swift-html-entities.git",
                  from: "4.0.1"),
         .package(url: "https://github.com/YusukeHosonuma/SwiftParamTest",
                  .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/tomlokhorst/XcodeEdit.git",
-                 from: "2.9.0")
+                 from: "2.9.0"),
+        .package(url: "https://github.com/jpsim/Yams.git",
+                 from: "5.0.5")
     ],
     targets: [
         .executableTarget(
@@ -43,7 +43,7 @@ let package = Package(
                 "APIKit",
                 "HeliumLogger",
                 .product(name: "HTMLEntities", package: "swift-html-entities"),
-                .product(name: "Yaml", package: "YamlSwift")
+                .product(name: "Yams", package: "Yams")
             ]
         ),
         .testTarget(

--- a/Sources/LicensePlistCore/Entity/Config.swift
+++ b/Sources/LicensePlistCore/Entity/Config.swift
@@ -37,11 +37,11 @@ public struct Config {
         }
         let versioned: [GitHub] = (value["github"]?.sequence ?? Node.Sequence())
             .map {
+                var gitHub: GitHub? = nil
                 if let map = $0.mapping, let owner = map["owner"]?.string, let name = map["name"]?.string {
-                    GitHub(name: name, nameSpecified: renames[name], owner: owner, version: map["version"]?.string)
-                } else {
-                    nil
+                    gitHub = GitHub(name: name, nameSpecified: renames[name], owner: owner, version: map["version"]?.string)
                 }
+                return gitHub
             }
             .compactMap { $0 }
         let options: GeneralOptions = (value["options"]?.mapping ?? Node.Mapping()).map {

--- a/Sources/LicensePlistCore/Entity/Config.swift
+++ b/Sources/LicensePlistCore/Entity/Config.swift
@@ -36,14 +36,12 @@ public struct Config {
                 "See: https://github.com/mono0926/LicensePlist/blob/master/Tests/LicensePlistTests/Resources/license_plist.yml .")
         }
         let versioned: [GitHub] = (value["github"]?.sequence ?? Node.Sequence())
-            .map {
-                var gitHub: GitHub? = nil
-                if let map = $0.mapping, let owner = map["owner"]?.string, let name = map["name"]?.string {
-                    gitHub = GitHub(name: name, nameSpecified: renames[name], owner: owner, version: map["version"]?.string)
+            .compactMap {
+                guard let map = $0.mapping, let owner = map["owner"]?.string, let name = map["name"]?.string else {
+                    return nil
                 }
-                return gitHub
+                return GitHub(name: name, nameSpecified: renames[name], owner: owner, version: map["version"]?.string)
             }
-            .compactMap { $0 }
         let options: GeneralOptions = (value["options"]?.mapping ?? Node.Mapping()).map {
             GeneralOptions.load($0, configBasePath: configBasePath)
         } ?? .empty

--- a/Sources/LicensePlistCore/Entity/Exclude.swift
+++ b/Sources/LicensePlistCore/Entity/Exclude.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Yaml
+import Yams
 import LoggerAPI
 
 public struct Exclude {
@@ -15,13 +15,12 @@ public struct Exclude {
         self.licenseType = licenseType
     }
 
-    public init?(from yaml: Yaml) {
+    public init?(from yaml: Node) {
         if let name = yaml.string {
             self.init(name: name, owner: nil, source: nil, licenseType: nil)
             return
         }
-
-        guard let dictionary = yaml.dictionary else {
+        guard let dictionary = yaml.mapping else {
             Log.warning("Attempt to load exclude failed. Supported YAML types are String and Dictionary.")
             return nil
         }

--- a/Sources/LicensePlistCore/Entity/GeneralOptions.swift
+++ b/Sources/LicensePlistCore/Entity/GeneralOptions.swift
@@ -1,6 +1,6 @@
 import Foundation
 import LoggerAPI
-import Yaml
+import Yams
 
 public struct GeneralOptions {
     public let outputPath: URL?
@@ -114,26 +114,27 @@ extension GeneralOptions {
 }
 
 extension GeneralOptions {
-    public static func load(_ raw: [Yaml: Yaml], configBasePath: URL) -> GeneralOptions {
-        return GeneralOptions(outputPath: raw["outputPath"]?.string.asPathURL(in: configBasePath),
-                              cartfilePath: raw["cartfilePath"]?.string.asPathURL(in: configBasePath),
-                              mintfilePath: raw["mintfilePath"]?.string.asPathURL(in: configBasePath),
-                              podsPath: raw["podsPath"]?.string.asPathURL(in: configBasePath),
-                              packagePaths: raw["packagePaths"]?.array?.compactMap { $0.string.asPathURL(in: configBasePath) },
-                              packageSourcesPath: raw["packageSourcesPath"]?.string.asPathURL(in: configBasePath, isDirectory: true),
-                              xcworkspacePath: raw["xcworkspacePath"]?.string.asPathURL(in: configBasePath),
-                              xcodeprojPath: raw["xcodeprojPath"]?.string.asPathURL(in: configBasePath),
-                              prefix: raw["prefix"]?.string,
-                              gitHubToken: raw["gitHubToken"]?.string,
-                              htmlPath: raw["htmlPath"]?.string.asPathURL(in: configBasePath),
-                              markdownPath: raw["markdownPath"]?.string.asPathURL(in: configBasePath),
-                              licenseFileNames: raw["licenseFileNames"]?.array?.compactMap(\.string),
-                              force: raw["force"]?.bool,
-                              addVersionNumbers: raw["addVersionNumbers"]?.bool,
-                              suppressOpeningDirectory: raw["suppressOpeningDirectory"]?.bool,
-                              singlePage: raw["singlePage"]?.bool,
-                              failIfMissingLicense: raw["failIfMissingLicense"]?.bool,
-                              addSources: raw["addSources"]?.bool,
-                              sandboxMode: raw["sandboxMode"]?.bool)
+    public static func load(_ raw: Node.Mapping, configBasePath: URL) -> GeneralOptions {
+        return GeneralOptions(
+            outputPath: raw["outputPath"]?.string.asPathURL(in: configBasePath),
+            cartfilePath: raw["cartfilePath"]?.string.asPathURL(in: configBasePath),
+            mintfilePath: raw["mintfilePath"]?.string.asPathURL(in: configBasePath),
+            podsPath: raw["podsPath"]?.string.asPathURL(in: configBasePath),
+            packagePaths: raw["packagePaths"]?.sequence?.compactMap { $0.string.asPathURL(in: configBasePath) },
+            packageSourcesPath: raw["packageSourcesPath"]?.string.asPathURL(in: configBasePath, isDirectory: true),
+            xcworkspacePath: raw["xcworkspacePath"]?.string.asPathURL(in: configBasePath),
+            xcodeprojPath: raw["xcodeprojPath"]?.string.asPathURL(in: configBasePath),
+            prefix: raw["prefix"]?.string,
+            gitHubToken: raw["gitHubToken"]?.string,
+            htmlPath: raw["htmlPath"]?.string.asPathURL(in: configBasePath),
+            markdownPath: raw["markdownPath"]?.string.asPathURL(in: configBasePath),
+            licenseFileNames: raw["licenseFileNames"]?.sequence?.compactMap { $0.string },
+            force: raw["force"]?.bool,
+            addVersionNumbers: raw["addVersionNumbers"]?.bool,
+            suppressOpeningDirectory: raw["suppressOpeningDirectory"]?.bool,
+            singlePage: raw["singlePage"]?.bool,
+            failIfMissingLicense: raw["failIfMissingLicense"]?.bool,
+            addSources: raw["addSources"]?.bool,
+            sandboxMode: raw["sandboxMode"]?.bool)
     }
 }

--- a/Sources/LicensePlistCore/Entity/Manual.swift
+++ b/Sources/LicensePlistCore/Entity/Manual.swift
@@ -42,17 +42,17 @@ extension Manual {
             let name = mapping["name"]?.string ?? ""
             let version = mapping["version"]?.string
             let source = mapping["source"]?.string
-            
+
             var body: String?
             if let raw = mapping["body"]?.string {
                 body = raw
             }
-            
+
             if let file = mapping["file"]?.string {
                 let url = configBasePath.appendingPathComponent(file)
                 body = try! String(contentsOf: url)
             }
-            
+
             let manual = Manual(name: name, source: source, nameSpecified: renames[name], version: version)
             manual.body = body  // This is so that we do not have to store a body at all ( for testing purposes mostly )
             return manual

--- a/Sources/LicensePlistCore/Entity/Manual.swift
+++ b/Sources/LicensePlistCore/Entity/Manual.swift
@@ -1,7 +1,7 @@
 import Foundation
 import APIKit
 import LoggerAPI
-import Yaml
+import Yams
 
 public class Manual: Library {
     public let name: String
@@ -36,33 +36,26 @@ extension Manual: CustomStringConvertible {
 }
 
 extension Manual {
-    public static func load(_ raw: [Yaml],
-                            renames: [String: String], configBasePath: URL) -> [Manual] {
-        return raw.map { (manualEntry) -> Manual in
-            var name = ""
+    public static func load(_ raw: Node.Sequence, renames: [String: String], configBasePath: URL) -> [Manual] {
+        return raw.compactMap({
+            let mapping = $0.mapping ?? Node.Mapping()
+            let name = mapping["name"]?.string ?? ""
+            let version = mapping["version"]?.string
+            let source = mapping["source"]?.string
+            
             var body: String?
-            var source: String?
-            var version: String?
-            for valuePair in manualEntry.dictionary ?? [:] {
-                switch valuePair.key.string ?? "" {
-                case "source":
-                    source = valuePair.value.string
-                case "name":
-                    name = valuePair.value.string ?? ""
-                case "version":
-                    version = valuePair.value.string
-                case "body":
-                    body = valuePair.value.string
-                case "file":
-                    let url = configBasePath.appendingPathComponent(valuePair.value.string!)
-                    body = try! String(contentsOf: url)
-                default:
-                    Log.warning("Tried to parse an unknown YAML key")
-                }
+            if let raw = mapping["body"]?.string {
+                body = raw
             }
+            
+            if let file = mapping["file"]?.string {
+                let url = configBasePath.appendingPathComponent(file)
+                body = try! String(contentsOf: url)
+            }
+            
             let manual = Manual(name: name, source: source, nameSpecified: renames[name], version: version)
             manual.body = body  // This is so that we do not have to store a body at all ( for testing purposes mostly )
             return manual
-        }
+        })
     }
 }

--- a/Tests/LicensePlistTests/Entity/ConfigTests.swift
+++ b/Tests/LicensePlistTests/Entity/ConfigTests.swift
@@ -201,12 +201,12 @@ class ConfigTests: XCTestCase {
         let result = config.applyManual(manuals: [shouldBeIncluded, Manual(name: "lib2", source: nil, nameSpecified: nil, version: nil)])
         XCTAssertEqual(result, [manual1, shouldBeIncluded])
     }
-    
+
     func test_mulitnewlineYaml() throws {
         let yaml = """
             manual:
               - body: |2
-        
+
                                         New Line
                                             new line
                     endline.

--- a/Tests/LicensePlistTests/Entity/ConfigTests.swift
+++ b/Tests/LicensePlistTests/Entity/ConfigTests.swift
@@ -17,6 +17,10 @@ class ConfigTests: XCTestCase {
                                                source: "https://webrtc.googlesource.com/src",
                                                nameSpecified: "Web RTC",
                                                version: "M61"),
+                                        Manual(name: "Firebase",
+                                               source: "https://github.com/firebase/firebase-ios-sdk",
+                                               nameSpecified: nil,
+                                               version: "4.0.0"),
                                         Manual(name: "Dummy License File", source: nil, nameSpecified: nil, version: nil)],
                               excludes: ["RxSwift", "ios-license-generator", "/^Core.*$/"],
                               renames: ["LicensePlist": "License Plist", "WebRTC": "Web RTC"],
@@ -197,5 +201,22 @@ class ConfigTests: XCTestCase {
         let result = config.applyManual(manuals: [shouldBeIncluded, Manual(name: "lib2", source: nil, nameSpecified: nil, version: nil)])
         XCTAssertEqual(result, [manual1, shouldBeIncluded])
     }
-
+    
+    func test_mulitnewlineYaml() throws {
+        let yaml = """
+            manual:
+              - body: |2
+        
+                                        New Line
+                                            new line
+                    endline.
+                name: name
+                source: source
+                version: 2.0.0
+        """
+        XCTAssertEqual(
+            "\n                      New Line\n                          new line\n  endline.\n",
+            Config(yaml: yaml, configBasePath: URL(string: "/LicensePlist")!).manuals[0].body
+        )
+    }
 }

--- a/Tests/LicensePlistTests/Entity/ExcludeTests.swift
+++ b/Tests/LicensePlistTests/Entity/ExcludeTests.swift
@@ -1,58 +1,54 @@
 import Foundation
 import XCTest
-import Yaml
+import Yams
 @testable import LicensePlistCore
 
 class ExcludeTests: XCTestCase {
 
     func testInit_yaml_dictionary() {
-        let testDict: [Yaml: Yaml] = [
+        let node: Node = [
             "name": "LicensePlist",
             "owner": "mono0926",
             "source": "https://github.com/mono0926/LicensePlist",
             "licenseType": "MIT"
         ]
-        let yaml = Yaml.dictionary(testDict)
-        let exclude = Exclude(from: yaml)
+        let exclude = Exclude(from: node)
         XCTAssertNotNil(exclude)
-        XCTAssertEqual(exclude!.name, yaml["name"].string)
-        XCTAssertEqual(exclude!.owner, yaml["owner"].string)
-        XCTAssertEqual(exclude!.source, yaml["source"].string)
-        XCTAssertEqual(exclude!.licenseType, yaml["licenseType"].string)
+        XCTAssertEqual(exclude!.name, node.mapping!["name"]!.string)
+        XCTAssertEqual(exclude!.owner, node.mapping!["owner"]!.string)
+        XCTAssertEqual(exclude!.source, node.mapping!["source"]!.string)
+        XCTAssertEqual(exclude!.licenseType, node.mapping!["licenseType"]!.string)
     }
 
     func testInit_yaml_dictionary_missing_some_properties() {
-        let testDict: [Yaml: Yaml] = [
+        let node: Node = [
             "name": "LicensePlist",
             "owner": "mono0926"
         ]
-        let yaml = Yaml.dictionary(testDict)
-        let exclude = Exclude(from: yaml)
+        let exclude = Exclude(from: node)
         XCTAssertNotNil(exclude)
-        XCTAssertEqual(exclude!.name, yaml["name"].string)
-        XCTAssertEqual(exclude!.owner, yaml["owner"].string)
+        XCTAssertEqual(exclude!.name, node.mapping!["name"]!.string)
+        XCTAssertEqual(exclude!.owner, node.mapping!["owner"]!.string)
         XCTAssertNil(exclude!.source)
         XCTAssertNil(exclude!.licenseType)
     }
 
     func testInit_yaml_no_properties() {
-        let testDict: [Yaml: Yaml] = [:]
-        let yaml = Yaml.dictionary(testDict)
-        let exclude = Exclude(from: yaml)
+        let node: Node = [:]
+        let exclude = Exclude(from: node)
         XCTAssertNil(exclude)
     }
 
     func testInit_yaml_invalid_properties() {
-        let testDict: [Yaml: Yaml] = ["invalid": "invalid"]
-        let yaml = Yaml.dictionary(testDict)
-        let exclude = Exclude(from: yaml)
+        let node: Node = ["invalid": "invalid"]
+        let exclude = Exclude(from: node)
         XCTAssertNil(exclude)
     }
 
     func testInit_yaml_string() {
         let testString = "LicensePlist"
-        let yaml = Yaml.string(testString)
-        let exclude = Exclude(from: yaml)
+        let node = Node(testString)
+        let exclude = Exclude(from: node)
         XCTAssertNotNil(exclude)
         XCTAssertEqual(exclude!.name, testString)
         XCTAssertNil(exclude!.owner)
@@ -61,17 +57,16 @@ class ExcludeTests: XCTestCase {
     }
 
     func testInit_yaml_invalid_yaml_type() {
-        let yaml = Yaml.bool(true)
-        let exclude = Exclude(from: yaml)
+        let node = Node([Node]())
+        let exclude = Exclude(from: node)
         XCTAssertNil(exclude)
     }
 
     func testInit_yaml_invalid_license_type() {
-        let testDict: [Yaml: Yaml] = [
+        let node: Node = [
             "licenseType": "invalid"
         ]
-        let yaml = Yaml.dictionary(testDict)
-        let exclude = Exclude(from: yaml)
+        let exclude = Exclude(from: node)
         XCTAssertNotNil(exclude)
     }
 }

--- a/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
@@ -107,12 +107,12 @@ class SwiftPackageFileReaderTests: XCTestCase {
               }
             },
             {
-              "identity" : "yamlswift",
+              "identity" : "yams",
               "kind" : "remoteSourceControl",
-              "location" : "https://github.com/behrang/YamlSwift.git",
+              "location" : "https://github.com/jpsim/Yams.git",
               "state" : {
-                "revision" : "287f5cab7da0d92eb947b5fd8151b203ae04a9a3",
-                "version" : "3.4.4"
+                "revision" : "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
+                "version" : "5.0.5"
               }
             }
           ],

--- a/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
+++ b/Tests/LicensePlistTests/Entity/SwiftPackageManagerTests.swift
@@ -187,12 +187,11 @@ class SwiftPackageManagerTests: XCTestCase {
                                                   version: "5.3.0",
                                                   packageDefinitionVersion: 2))
         let packageLast = try XCTUnwrap(packages.last)
-        XCTAssertEqual(packageLast, SwiftPackage(package: "yamlswift",
-                                                 repositoryURL: "https://github.com/behrang/YamlSwift.git",
-                                                 revision: "287f5cab7da0d92eb947b5fd8151b203ae04a9a3",
-                                                 version: "3.4.4",
+        XCTAssertEqual(packageLast, SwiftPackage(package: "yams",
+                                                 repositoryURL: "https://github.com/jpsim/Yams.git",
+                                                 revision: "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
+                                                 version: "5.0.5",
                                                  packageDefinitionVersion: 2))
-
     }
 
     // MARK: - SPM v2

--- a/Tests/LicensePlistTests/Resources/license_plist.yml
+++ b/Tests/LicensePlistTests/Resources/license_plist.yml
@@ -65,6 +65,15 @@ manual:
       (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
       OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+  - source: https://github.com/firebase/firebase-ios-sdk
+    name: Firebase
+    version: 4.0.0
+    body: |2
+                                      Apache License
+                                Version 2.0, January 2004
+                              http://www.apache.org/licenses/
+        TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
 # Specify license files manually
   - name: "Dummy License File"
     file: "dummy_license.txt"


### PR DESCRIPTION
YamlSwift can't parse yaml like below

```yaml
manual:
  - source: https://github.com/firebase/firebase-ios-sdk
    name: Firebase
    version: 4.0.0
    body: |2
                                      Apache License
                                Version 2.0, January 2004
                              http://www.apache.org/licenses/
        TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
```


so I replaced yaml parser Library, YamlSwift to Yams