### PR TITLE
Use `githubLicenses` for the latest_result.txt output

### DIFF
--- a/Sources/LicensePlistCore/Entity/GitHubLicense.swift
+++ b/Sources/LicensePlistCore/Entity/GitHubLicense.swift
@@ -13,6 +13,10 @@ public struct GitHubLicense: License, Equatable {
     }
 }
 
+extension GitHubLicense: CustomStringConvertible {
+    public var description: String { library.description }
+}
+
 extension GitHubLicense {
 
     public enum DownloadError: Error {

--- a/Sources/LicensePlistCore/Entity/PlistInfo.swift
+++ b/Sources/LicensePlistCore/Entity/PlistInfo.swift
@@ -72,17 +72,18 @@ struct PlistInfo {
 
         let config = options.config
 
-        let contents = (cocoaPodsLicenses.map { String(describing: $0) } +
-            githubLibraries.map { String(describing: $0) } +
-            manualLicenses.map { String(describing: $0) } +
-            ["add-version-numbers: \(options.config.addVersionNumbers)", "LicensePlist Version: \(Consts.version)"])
-            .joined(separator: "\n\n")
+        let potential = makeSummary(
+            licenseDescriptions: (
+                cocoaPodsLicenses.map { String(describing: $0) } +
+                githubLibraries.map { String(describing: $0) } +
+                manualLicenses.map { String(describing: $0) }
+            )
+        )
         let savePath = options.outputPath.appendingPathComponent("\(options.prefix).latest_result.txt")
-        if let previous = savePath.lp.read(), previous == contents, !config.force {
+        if let previous = savePath.lp.read(), previous == potential, !config.force {
             Log.warning("Completed because no diff. You can execute force by `--force` flag.")
             exit(0)
         }
-        summary = contents
         summaryPath = savePath
     }
 

--- a/Sources/LicensePlistCore/Entity/PlistInfo.swift
+++ b/Sources/LicensePlistCore/Entity/PlistInfo.swift
@@ -200,4 +200,12 @@ struct PlistInfo {
             fatalError("'--package-sources-path' must be specified when using '--sandbox-mode'")
         }
     }
+
+    private func makeSummary(licenseDescriptions: [String]) -> String {
+        let additionalInfos: [String] = [
+            "add-version-numbers: \(options.config.addVersionNumbers)",
+            "LicensePlist Version: \(Consts.version)"
+        ]
+        return (licenseDescriptions + additionalInfos).joined(separator: "\n\n")
+    }
 }

--- a/Sources/LicensePlistCore/Entity/PlistInfo.swift
+++ b/Sources/LicensePlistCore/Entity/PlistInfo.swift
@@ -101,13 +101,19 @@ struct PlistInfo {
             let githubLicenses = githubLicenses,
             let manualLicenses = manualLicenses else { preconditionFailure() }
 
-        licenses = ((cocoaPodsLicenses as [LicenseInfo]) + (githubLicenses as [LicenseInfo]) + (manualLicenses as [LicenseInfo]))
+        let licenseInfos: [LicenseInfo] = cocoaPodsLicenses + githubLicenses + manualLicenses
+
+        licenses = licenseInfos
             .reduce([String: LicenseInfo]()) { sum, e in
                 var sum = sum
                 sum[e.name] = e
                 return sum
             }.values
             .sorted { $0.name.lowercased() < $1.name.lowercased() }
+
+        summary = makeSummary(
+            licenseDescriptions: licenseInfos.map { String(describing: $0) }
+        )
     }
 
     func outputPlist() {

--- a/Sources/LicensePlistCore/LicensePlist.swift
+++ b/Sources/LicensePlistCore/LicensePlist.swift
@@ -47,7 +47,7 @@ public final class LicensePlist {
         }
     }
 
-    /// Gets the result of attempting to read the `Package.resolved` from ether a Xcode Workspace or Xcode project.
+    /// Gets the result of attempting to read the `Package.resolved` from either a Xcode Workspace or Xcode project.
     /// - note: If an Xcode workspace is found it is preferred over a Xcode project.
     private func xcodeFileReadResult(xcworkspacePath: URL, xcodeprojPath: URL) throws -> String? {
 

--- a/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
+++ b/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
@@ -124,12 +124,12 @@ class PlistInfoTests: XCTestCase {
         target.githubLicenses = [githubLicense]
         let expectedSummary = """
         name: LicensePlist, nameSpecified: LicensePlist, owner: mono0926, version: 0.0.1, source: https://github.com/mono0926/LicensePlist
-        
+
         name: FooBar, nameSpecified: FooBar, version: 0.0.1
         body: body…
-        
+
         add-version-numbers: false
-        
+
         LicensePlist Version: 3.25.1
         """
 

--- a/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
+++ b/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
@@ -88,8 +88,6 @@ class PlistInfoTests: XCTestCase {
         XCTAssertNil(target.summaryPath)
         target.compareWithLatestSummary()
 
-        XCTAssertEqual(target.summary,
-                       "add-version-numbers: false\n\nLicensePlist Version: 3.25.1")
         XCTAssertNotNil(target.summaryPath)
     }
 
@@ -111,7 +109,7 @@ class PlistInfoTests: XCTestCase {
 
     func testCollectLicenseInfos() throws {
         var target = PlistInfo(options: options)
-        let github = GitHub(name: "LicensePlist", nameSpecified: nil, owner: "mono0926", version: nil)
+        let github = GitHub(name: "LicensePlist", nameSpecified: "LicensePlist", owner: "mono0926", version: "0.0.1")
         let githubLicense = GitHubLicense(library: github,
                                           body: "body",
                                           githubResponse: LicenseResponse(content: "",
@@ -119,11 +117,21 @@ class PlistInfoTests: XCTestCase {
                                                                           kind: LicenseKindResponse(name: "name",
                                                                                                     spdxId: nil)))
         target.cocoaPodsLicenses = []
-        let manual = Manual(name: "FooBar", source: "https://foo.bar", nameSpecified: nil, version: nil)
+        let manual = Manual(name: "FooBar", source: "https://foo.bar", nameSpecified: "FooBar", version: "0.0.1")
         let manualLicense = ManualLicense(library: manual,
                                           body: "body")
         target.manualLicenses = [manualLicense]
         target.githubLicenses = [githubLicense]
+        let expectedSummary = """
+        name: LicensePlist, nameSpecified: LicensePlist, owner: mono0926, version: 0.0.1, source: https://github.com/mono0926/LicensePlist
+        
+        name: FooBar, nameSpecified: FooBar, version: 0.0.1
+        body: body…
+        
+        add-version-numbers: false
+        
+        LicensePlist Version: 3.25.1
+        """
 
         XCTAssertNil(target.licenses)
         target.collectLicenseInfos()
@@ -131,6 +139,7 @@ class PlistInfoTests: XCTestCase {
         XCTAssertEqual(licenses.count, 2)
         let license = licenses.last
         XCTAssertEqual(license?.name, "LicensePlist")
+        XCTAssertEqual(target.summary, expectedSummary)
     }
 
     // MEMO: No result assertions


### PR DESCRIPTION
## Background
Currently, `githubLibraries` list of `PlistInfo` is used for the latest\_result.txt output. `githubLibraries` is the list before loading GitHub licenses. As a result, libraries whose licenses failed to load are also written to latest\_result.txt.

This causes issues such as GitHub licenses not being reloaded even if there are licenses that failed to load, because there is no diff between the latest latest\_result.txt and the one that was completely loaded before.

## Solution
I've made the following changes:
- The latest_result.txt output now uses `githubLicenses` instead of `githubLibraries`.
- The assignment to the `summary` property is now executed in the `collectLicenseInfos` function rather than in `compareWithLatestSummary`.

The output format remains unchanged, as it still uses the `library` property description of `GitHubLicense` type, which is the same `GitHub` type as before.

Thank you.
