### PR TITLE
fix: Encourage users to create fine-grained PATs instead of classic tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ You can see options by `license-plist --help`.
 
 - Default: None.
 - LicensePlist uses GitHub API, so sometimes API limit errors occur. You can avoid those errors by specifying a GitHub token.
-- [You can generate a token here](https://github.com/settings/tokens/new)
-    - `repo` scope is needed.
+- [You can generate a token here](https://github.com/settings/personal-access-tokens/new)
+    - Repository access for `Public repositories` is needed.
 - You can also pass the GitHub token via the `LICENSE_PLIST_GITHUB_TOKEN` environment variable.
 
 #### `--config-path`


### PR DESCRIPTION
The current `README.md` instructs users to create **"classic tokens"**.
However, GitHub now recommends using **"fine-grained personal access tokens (fine-grained PATs)"**, which provide more granular control and improved security.

> Your personal access token (classic) can access every repository that you can access. GitHub recommends that you use fine-grained personal access tokens instead, which you can restrict to specific repositories.
> https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic

This PR updates the `README.md` to encourage users to create **"fine-grained PATs"** instead of **"classic tokens"**.

I have confirmed that LicensePlist works with fine-grained PATs with public repo access.