### PR TITLE
Updated Yams to v6.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "fb60288400d91fed9489a94ce0682963f0d0e5afd6a97bd6d8e2e2d11a3228a6",
   "pins" : [
     {
       "identity" : "apikit",
@@ -95,10 +96,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
-        "version" : "5.0.5"
+        "revision" : "d41ba4e7164c0838c6d48351f7575f7f762151fe",
+        "version" : "6.1.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(url: "https://github.com/tomlokhorst/XcodeEdit.git",
                  from: "2.9.0"),
         .package(url: "https://github.com/jpsim/Yams.git",
-                 from: "5.0.5")
+                 from: "6.0.2")
     ],
     targets: [
         .executableTarget(

--- a/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
@@ -15,6 +15,7 @@ class SwiftPackageFileReaderTests: XCTestCase {
     var packageResolvedText: String {
         return #"""
         {
+          "originHash" : "fb60288400d91fed9489a94ce0682963f0d0e5afd6a97bd6d8e2e2d11a3228a6",
           "pins" : [
             {
               "identity" : "apikit",
@@ -111,12 +112,12 @@ class SwiftPackageFileReaderTests: XCTestCase {
               "kind" : "remoteSourceControl",
               "location" : "https://github.com/jpsim/Yams.git",
               "state" : {
-                "revision" : "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
-                "version" : "5.0.5"
+                "revision" : "d41ba4e7164c0838c6d48351f7575f7f762151fe",
+                "version" : "6.1.0"
               }
             }
           ],
-          "version" : 2
+          "version" : 3
         }
         """#
     }


### PR DESCRIPTION
Hi,

This PR updates Yams to v6.

When using SwiftLint v0.61.0 together with LicensePlist, I encountered a Yams version dependency error. Updating Yams resolves the issue.

```
xcodebuild: error: Could not resolve package dependencies:
  Failed to resolve dependencies Dependencies could not be resolved because root depends on 'licenseplist' 3.27.1 and root depends on 'swiftlint' 0.61.0.
'swiftlint' is incompatible with 'licenseplist' because 'swiftlint' 0.61.0 depends on 'yams' 6.0.2..<7.0.0 and 'licenseplist' 3.27.1 depends on 'yams' 5.0.5..<6.0.0.
```

Thanks.