### PR TITLE
fix: resolve SourcePackages path for Xcode 26

### DIFF
--- a/Plugins/GenerateAcknowledgementsCommand/GenerateAcknowledgementsCommand.swift
+++ b/Plugins/GenerateAcknowledgementsCommand/GenerateAcknowledgementsCommand.swift
@@ -29,12 +29,26 @@ extension GenerateAcknowledgementsCommand: XcodeCommandPlugin {
         return arguments
     }
     
-    // Returns default folder with checked out package sources
+    // Returns default folder with checked out package sources.
+    //
+    // Starting from Xcode 16.3, `pluginWorkDirectoryURL` no longer points to a
+    // directory under `SourcePackages` but instead to:
+    //   `Build/Intermediates.noindex/.../GenerateAcknowledgementsCommand/`
+    //
+    // See https://github.com/mono0926/LicensePlist/issues/251 for details.
     private func packageSourcesPath(context: XcodePluginContext) -> String {
-        return context.pluginWorkDirectoryURL
+        var packageSourcesPath = context.pluginWorkDirectoryURL
             .deletingLastPathComponent()
             .deletingLastPathComponent()
-            .path
+
+        if packageSourcesPath.lastPathComponent != "SourcePackages" {
+            packageSourcesPath = packageSourcesPath
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("SourcePackages")
+        }
+
+        return packageSourcesPath.path
     }
 }
 #endif

--- a/Plugins/LicensePlistBuildTool/LicensePlistBuildTool.swift
+++ b/Plugins/LicensePlistBuildTool/LicensePlistBuildTool.swift
@@ -30,10 +30,6 @@ extension LicensePlistBuildTool: XcodeBuildToolPlugin {
         // `Build/Intermediates.noindex/BuildToolPluginIntermediates/MyApp.output/...`
         //
         // See https://github.com/mono0926/LicensePlist/issues/240 for more details.
-        let isInSourcePackagesDirectory = context.pluginWorkDirectoryURL.pathComponents.contains {
-            $0 == "SourcePackages"
-        }
-
         var packageSourcesPath = context.pluginWorkDirectoryURL
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -42,11 +38,11 @@ extension LicensePlistBuildTool: XcodeBuildToolPlugin {
 
         // If we are not in a SourcePackages directory, we need to go up two more levels and
         // then append SourcePackages to the path.
-        if !isInSourcePackagesDirectory {
+        if packageSourcesPath.lastPathComponent != "SourcePackages" {
             packageSourcesPath = packageSourcesPath
                 .deletingLastPathComponent()
                 .deletingLastPathComponent()
-                .appending(component: "SourcePackages")
+                .appendingPathComponent("SourcePackages")
         }
 
         // Output directory inside build output directory

--- a/Tests/LicensePlistTests/PluginPathResolutionTests.swift
+++ b/Tests/LicensePlistTests/PluginPathResolutionTests.swift
@@ -1,10 +1,61 @@
 import XCTest
 
+/// Pure-function mirror of the path resolution algorithm used by both Xcode plugins.
+///
+/// Plugin targets cannot be imported in tests (SPM limitation), so this helper
+/// replicates the exact algorithm. Any change to a plugin's `packageSourcesPath`
+/// must be reflected here — the tests below will catch regressions in the algorithm
+/// itself (correct number of `deletingLastPathComponent` calls, `lastPathComponent`
+/// guard, and `appendingPathComponent` for macOS compatibility).
+enum PluginPathResolution {
+
+    /// Mirrors GenerateAcknowledgementsCommand.packageSourcesPath.
+    ///
+    /// Old Xcode path (2 levels above pluginWorkDir):
+    ///   {DerivedData}/xxx/SourcePackages/plugins/GenerateAcknowledgementsCommand/
+    /// New Xcode path (4 levels above pluginWorkDir + append):
+    ///   {DerivedData}/xxx/Build/Intermediates.noindex/CommandPluginIntermediates/GenerateAcknowledgementsCommand/
+    static func commandPlugin(pluginWorkDirectoryURL: URL) -> URL {
+        var packageSourcesPath = pluginWorkDirectoryURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        if packageSourcesPath.lastPathComponent != "SourcePackages" {
+            packageSourcesPath = packageSourcesPath
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("SourcePackages")
+        }
+
+        return packageSourcesPath
+    }
+
+    /// Mirrors LicensePlistBuildTool path resolution (from PR #241).
+    ///
+    /// Old Xcode path (4 levels above pluginWorkDir):
+    ///   {DerivedData}/xxx/SourcePackages/plugins/MyApp.output/MyApp/LicensePlistBuildTool/
+    /// New Xcode path (6 levels above pluginWorkDir + append):
+    ///   {DerivedData}/xxx/Build/Intermediates.noindex/BuildToolPluginIntermediates/MyApp.output/MyApp/LicensePlistBuildTool/
+    static func buildToolPlugin(pluginWorkDirectoryURL: URL) -> URL {
+        var packageSourcesPath = pluginWorkDirectoryURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        if packageSourcesPath.lastPathComponent != "SourcePackages" {
+            packageSourcesPath = packageSourcesPath
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("SourcePackages")
+        }
+
+        return packageSourcesPath
+    }
+}
+
 /// Tests the path resolution algorithm used by Xcode plugins to locate
 /// the SourcePackages directory from `pluginWorkDirectoryURL`.
-///
-/// Plugin targets cannot be imported in tests, so these tests validate the
-/// algorithm directly using URL manipulation — the same operations the plugins perform.
 final class PluginPathResolutionTests: XCTestCase {
 
     // MARK: - GenerateAcknowledgementsCommand path resolution
@@ -15,7 +66,7 @@ final class PluginPathResolutionTests: XCTestCase {
     func testCommandPlugin_oldXcode_resolvesSourcePackages() {
         let pluginWorkDir = URL(fileURLWithPath: "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages/plugins/GenerateAcknowledgementsCommand")
 
-        let resolved = resolvePackageSourcesPath_commandPlugin(pluginWorkDirectoryURL: pluginWorkDir)
+        let resolved = PluginPathResolution.commandPlugin(pluginWorkDirectoryURL: pluginWorkDir)
 
         XCTAssertEqual(resolved.path, "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages")
     }
@@ -27,19 +78,9 @@ final class PluginPathResolutionTests: XCTestCase {
     func testCommandPlugin_newXcode_resolvesSourcePackages() {
         let pluginWorkDir = URL(fileURLWithPath: "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/Build/Intermediates.noindex/CommandPluginIntermediates/GenerateAcknowledgementsCommand")
 
-        let resolved = resolvePackageSourcesPath_commandPlugin(pluginWorkDirectoryURL: pluginWorkDir)
+        let resolved = PluginPathResolution.commandPlugin(pluginWorkDirectoryURL: pluginWorkDir)
 
         XCTAssertEqual(resolved.path, "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages")
-    }
-
-    /// Verifies that checkouts can be found under the resolved path.
-    func testCommandPlugin_newXcode_checkoutsPath() {
-        let pluginWorkDir = URL(fileURLWithPath: "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/Build/Intermediates.noindex/CommandPluginIntermediates/GenerateAcknowledgementsCommand")
-
-        let resolved = resolvePackageSourcesPath_commandPlugin(pluginWorkDirectoryURL: pluginWorkDir)
-        let checkoutsPath = resolved.appendingPathComponent("checkouts")
-
-        XCTAssertEqual(checkoutsPath.path, "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages/checkouts")
     }
 
     // MARK: - LicensePlistBuildTool path resolution (regression guard)
@@ -49,7 +90,7 @@ final class PluginPathResolutionTests: XCTestCase {
     func testBuildToolPlugin_oldXcode_resolvesSourcePackages() {
         let pluginWorkDir = URL(fileURLWithPath: "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages/plugins/MyApp.output/MyApp/LicensePlistBuildTool")
 
-        let resolved = resolvePackageSourcesPath_buildToolPlugin(pluginWorkDirectoryURL: pluginWorkDir)
+        let resolved = PluginPathResolution.buildToolPlugin(pluginWorkDirectoryURL: pluginWorkDir)
 
         XCTAssertEqual(resolved.path, "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages")
     }
@@ -59,52 +100,8 @@ final class PluginPathResolutionTests: XCTestCase {
     func testBuildToolPlugin_newXcode_resolvesSourcePackages() {
         let pluginWorkDir = URL(fileURLWithPath: "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/Build/Intermediates.noindex/BuildToolPluginIntermediates/MyApp.output/MyApp/LicensePlistBuildTool")
 
-        let resolved = resolvePackageSourcesPath_buildToolPlugin(pluginWorkDirectoryURL: pluginWorkDir)
+        let resolved = PluginPathResolution.buildToolPlugin(pluginWorkDirectoryURL: pluginWorkDir)
 
         XCTAssertEqual(resolved.path, "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages")
-    }
-
-    // MARK: - Algorithm implementations (mirrors plugin code)
-
-    /// Mirrors GenerateAcknowledgementsCommand.packageSourcesPath
-    private func resolvePackageSourcesPath_commandPlugin(pluginWorkDirectoryURL: URL) -> URL {
-        let isInSourcePackagesDirectory = pluginWorkDirectoryURL.pathComponents.contains {
-            $0 == "SourcePackages"
-        }
-
-        var packageSourcesPath = pluginWorkDirectoryURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-
-        if !isInSourcePackagesDirectory {
-            packageSourcesPath = packageSourcesPath
-                .deletingLastPathComponent()
-                .deletingLastPathComponent()
-                .appending(component: "SourcePackages")
-        }
-
-        return packageSourcesPath
-    }
-
-    /// Mirrors LicensePlistBuildTool.packageSourcesPath (from PR #241)
-    private func resolvePackageSourcesPath_buildToolPlugin(pluginWorkDirectoryURL: URL) -> URL {
-        let isInSourcePackagesDirectory = pluginWorkDirectoryURL.pathComponents.contains {
-            $0 == "SourcePackages"
-        }
-
-        var packageSourcesPath = pluginWorkDirectoryURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-
-        if !isInSourcePackagesDirectory {
-            packageSourcesPath = packageSourcesPath
-                .deletingLastPathComponent()
-                .deletingLastPathComponent()
-                .appending(component: "SourcePackages")
-        }
-
-        return packageSourcesPath
     }
 }

--- a/Tests/LicensePlistTests/PluginPathResolutionTests.swift
+++ b/Tests/LicensePlistTests/PluginPathResolutionTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+
+/// Tests the path resolution algorithm used by Xcode plugins to locate
+/// the SourcePackages directory from `pluginWorkDirectoryURL`.
+///
+/// Plugin targets cannot be imported in tests, so these tests validate the
+/// algorithm directly using URL manipulation — the same operations the plugins perform.
+final class PluginPathResolutionTests: XCTestCase {
+
+    // MARK: - GenerateAcknowledgementsCommand path resolution
+
+    /// Old Xcode (<=16.2): pluginWorkDirectoryURL is under SourcePackages.
+    /// Path: {DerivedData}/xxx/SourcePackages/plugins/GenerateAcknowledgementsCommand/
+    /// Going up 2 levels should yield {DerivedData}/xxx/SourcePackages/
+    func testCommandPlugin_oldXcode_resolvesSourcePackages() {
+        let pluginWorkDir = URL(fileURLWithPath: "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages/plugins/GenerateAcknowledgementsCommand")
+
+        let resolved = resolvePackageSourcesPath_commandPlugin(pluginWorkDirectoryURL: pluginWorkDir)
+
+        XCTAssertEqual(resolved.path, "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages")
+    }
+
+    /// New Xcode (>=16.3 / Xcode 26): pluginWorkDirectoryURL is under Build/Intermediates.noindex.
+    /// Path: {DerivedData}/xxx/Build/Intermediates.noindex/CommandPluginIntermediates/GenerateAcknowledgementsCommand/
+    /// The naive 2-level ascent would land at Build/Intermediates.noindex/ — wrong.
+    /// The fix must detect the absence of "SourcePackages" and navigate to {DerivedData}/xxx/SourcePackages/
+    func testCommandPlugin_newXcode_resolvesSourcePackages() {
+        let pluginWorkDir = URL(fileURLWithPath: "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/Build/Intermediates.noindex/CommandPluginIntermediates/GenerateAcknowledgementsCommand")
+
+        let resolved = resolvePackageSourcesPath_commandPlugin(pluginWorkDirectoryURL: pluginWorkDir)
+
+        XCTAssertEqual(resolved.path, "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages")
+    }
+
+    /// Verifies that checkouts can be found under the resolved path.
+    func testCommandPlugin_newXcode_checkoutsPath() {
+        let pluginWorkDir = URL(fileURLWithPath: "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/Build/Intermediates.noindex/CommandPluginIntermediates/GenerateAcknowledgementsCommand")
+
+        let resolved = resolvePackageSourcesPath_commandPlugin(pluginWorkDirectoryURL: pluginWorkDir)
+        let checkoutsPath = resolved.appendingPathComponent("checkouts")
+
+        XCTAssertEqual(checkoutsPath.path, "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages/checkouts")
+    }
+
+    // MARK: - LicensePlistBuildTool path resolution (regression guard)
+
+    /// Old Xcode: pluginWorkDirectoryURL is under SourcePackages.
+    /// Path: {DerivedData}/xxx/SourcePackages/plugins/MyApp.output/MyApp/LicensePlistBuildTool/
+    func testBuildToolPlugin_oldXcode_resolvesSourcePackages() {
+        let pluginWorkDir = URL(fileURLWithPath: "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages/plugins/MyApp.output/MyApp/LicensePlistBuildTool")
+
+        let resolved = resolvePackageSourcesPath_buildToolPlugin(pluginWorkDirectoryURL: pluginWorkDir)
+
+        XCTAssertEqual(resolved.path, "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages")
+    }
+
+    /// New Xcode: pluginWorkDirectoryURL is under Build/Intermediates.noindex.
+    /// Path: {DerivedData}/xxx/Build/Intermediates.noindex/BuildToolPluginIntermediates/MyApp.output/MyApp/LicensePlistBuildTool/
+    func testBuildToolPlugin_newXcode_resolvesSourcePackages() {
+        let pluginWorkDir = URL(fileURLWithPath: "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/Build/Intermediates.noindex/BuildToolPluginIntermediates/MyApp.output/MyApp/LicensePlistBuildTool")
+
+        let resolved = resolvePackageSourcesPath_buildToolPlugin(pluginWorkDirectoryURL: pluginWorkDir)
+
+        XCTAssertEqual(resolved.path, "/Users/user/Library/Developer/Xcode/DerivedData/MyApp-abc/SourcePackages")
+    }
+
+    // MARK: - Algorithm implementations (mirrors plugin code)
+
+    /// Mirrors GenerateAcknowledgementsCommand.packageSourcesPath
+    private func resolvePackageSourcesPath_commandPlugin(pluginWorkDirectoryURL: URL) -> URL {
+        let isInSourcePackagesDirectory = pluginWorkDirectoryURL.pathComponents.contains {
+            $0 == "SourcePackages"
+        }
+
+        var packageSourcesPath = pluginWorkDirectoryURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        if !isInSourcePackagesDirectory {
+            packageSourcesPath = packageSourcesPath
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appending(component: "SourcePackages")
+        }
+
+        return packageSourcesPath
+    }
+
+    /// Mirrors LicensePlistBuildTool.packageSourcesPath (from PR #241)
+    private func resolvePackageSourcesPath_buildToolPlugin(pluginWorkDirectoryURL: URL) -> URL {
+        let isInSourcePackagesDirectory = pluginWorkDirectoryURL.pathComponents.contains {
+            $0 == "SourcePackages"
+        }
+
+        var packageSourcesPath = pluginWorkDirectoryURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        if !isInSourcePackagesDirectory {
+            packageSourcesPath = packageSourcesPath
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appending(component: "SourcePackages")
+        }
+
+        return packageSourcesPath
+    }
+}


### PR DESCRIPTION
## Summary

- Applies the same `lastPathComponent` guard from `LicensePlistBuildTool` (#241) to `GenerateAcknowledgementsCommand`, which was still using the old hard-coded 2-level ascent
- Replaces `appending(component:)` with `appendingPathComponent(_:)` in the build tool plugin for broader macOS SDK compatibility
- Adds path resolution unit tests covering both old (<=16.2) and new (>=16.3 / Xcode 26) directory layouts for both plugins

Starting from Xcode 16.3, `pluginWorkDirectoryURL` points to `Build/Intermediates.noindex/CommandPluginIntermediates/` instead of `SourcePackages/plugins/`. The command plugin was not updated in #241 and fails to find packages.

Ref: #251

## Test plan

- [x] `swift build` passes
- [x] Path resolution tests validate 4 scenarios (old/new Xcode x command/build tool plugin)
- [x] Both plugins resolve to `SourcePackages/` on old and new Xcode layouts