### PR TITLE
Fix: Allow the tool to work from arbitrary working directories

### DIFF
--- a/Plugins/LicensePlistBuildTool/LicensePlistBuildTool.swift
+++ b/Plugins/LicensePlistBuildTool/LicensePlistBuildTool.swift
@@ -52,12 +52,15 @@ extension LicensePlistBuildTool: XcodeBuildToolPlugin {
         // Output directory inside build output directory
         let outputDirectoryPath = context.pluginWorkDirectoryURL.appending(component: "com.mono0926.LicensePlist.Output")
         try fileManager.createDirectory(atPath: outputDirectoryPath.path, withIntermediateDirectories: true)
+        
+        let rootPath = context.xcodeProject.directoryURL
 
         return [
             .prebuildCommand(displayName: "LicensePlist is processing licenses...",
                              executable: licensePlist.url,
                              arguments: ["--sandbox-mode",
                                          "--config-path", configPath.path,
+                                         "--root-path", rootPath.path,
                                          "--package-sources-path", packageSourcesPath.path,
                                          "--output-path", outputDirectoryPath.path],
                              outputFilesDirectory: context.pluginWorkDirectoryURL)

--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -23,6 +23,9 @@ struct LicensePlist: ParsableCommand {
     static let configuration = CommandConfiguration(version: Consts.version,
                                                     subcommands: [AddAcknowledgementsCopyScript.self])
 
+    @Option(name: .long, completion: .directory)
+    var rootPath: String?
+    
     @Option(name: .long, completion: .file())
     var cartfilePath: String?
 
@@ -105,24 +108,27 @@ struct LicensePlist: ParsableCommand {
         Logger.configure(logLevel: logLevel, colorCommandLineFlag: color)
 
         let config = getConfig()
-        let cartfilePath = cartfilePath.asPathURL(other: config.options.cartfilePath, default: Consts.cartfileName)
-        let mintfilePath = mintfilePath.asPathURL(other: config.options.mintfilePath, default: Consts.mintfileName)
-        let nestfilePath = nestfilePath.asPathURL(other: config.options.nestfilePath, default: Consts.nestfileName)
-        let podsPath = podsPath.asPathURL(other: config.options.podsPath, default: Consts.podsDirectoryName)
+        let rootPath = rootPath.asPathURL()
+        
+        let cartfilePath = cartfilePath.asPathURL(other: config.options.cartfilePath, default: Consts.cartfileName, relativeTo: rootPath)
+        let mintfilePath = mintfilePath.asPathURL(other: config.options.mintfilePath, default: Consts.mintfileName, relativeTo: rootPath)
+        let nestfilePath = nestfilePath.asPathURL(other: config.options.nestfilePath, default: Consts.nestfileName, relativeTo: rootPath)
+        let podsPath = podsPath.asPathURL(other: config.options.podsPath, default: Consts.podsDirectoryName, relativeTo: rootPath)
         let configPackagePaths = config.options.packagePaths ?? [URL(fileURLWithPath: Consts.packageName)]
         let packagePaths = packagePaths.isEmpty ? configPackagePaths : packagePaths.map { URL(fileURLWithPath: $0) }
-        let packageSourcesPath = packageSourcesPath.asPathURL(other: config.options.packageSourcesPath, isDirectory: true)
-        let xcworkspacePath = xcworkspacePath.asPathURL(other: config.options.xcworkspacePath, default: Consts.xcworkspacePath)
-        let xcodeprojPath = xcodeprojPath.asPathURL(other: config.options.xcodeprojPath, default: Consts.xcodeprojPath)
-        let outputPath = outputPath.asPathURL(other: config.options.outputPath, default: Consts.outputPath)
+        let packageSourcesPath = packageSourcesPath.asPathURL(other: config.options.packageSourcesPath, isDirectory: true, relativeTo: rootPath)
+        let xcworkspacePath = xcworkspacePath.asPathURL(other: config.options.xcworkspacePath, default: Consts.xcworkspacePath, relativeTo: rootPath)
+        let xcodeprojPath = xcodeprojPath.asPathURL(other: config.options.xcodeprojPath, default: Consts.xcodeprojPath, relativeTo: rootPath)
+        let outputPath = outputPath.asPathURL(other: config.options.outputPath, default: Consts.outputPath, relativeTo: rootPath)
         let githubToken = githubToken ?? config.options.gitHubToken ?? Environment.shared[.githubToken]
         let prefix = prefix ?? config.options.prefix ?? Consts.prefix
-        let htmlPath = htmlPath.asPathURL(other: config.options.htmlPath)
-        let markdownPath = markdownPath.asPathURL(other: config.options.markdownPath)
-        let csvPath = csvPath.asPathURL(other: config.options.csvPath)
+        let htmlPath = htmlPath.asPathURL(other: config.options.htmlPath, relativeTo: rootPath)
+        let markdownPath = markdownPath.asPathURL(other: config.options.markdownPath, relativeTo: rootPath)
+        let csvPath = csvPath.asPathURL(other: config.options.csvPath, relativeTo: rootPath)
         let configLicenseFileNames = config.options.licenseFileNames ?? Consts.licenseFileNames
         let licenseFileNames = licenseFileNames.isEmpty ? configLicenseFileNames : licenseFileNames
-        let options = Options(outputPath: outputPath,
+        let options = Options(rootPath: rootPath,
+                              outputPath: outputPath,
                               cartfilePath: cartfilePath,
                               mintfilePath: mintfilePath,
                               nestfilePath: nestfilePath,

--- a/Sources/LicensePlistCore/Entity/Options.swift
+++ b/Sources/LicensePlistCore/Entity/Options.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public struct Options: Sendable {
+    public let rootPath: URL?
     public let outputPath: URL
     public let cartfilePath: URL
     public let mintfilePath: URL
@@ -18,7 +19,8 @@ public struct Options: Sendable {
     public let licenseFileNames: [String]
     public let config: Config
 
-    public static let empty = Options(outputPath: URL(fileURLWithPath: ""),
+    public static let empty = Options(rootPath: nil,
+                                      outputPath: URL(fileURLWithPath: ""),
                                       cartfilePath: URL(fileURLWithPath: ""),
                                       mintfilePath: URL(fileURLWithPath: ""),
                                       nestfilePath: URL(fileURLWithPath: ""),
@@ -35,7 +37,8 @@ public struct Options: Sendable {
                                       licenseFileNames: [],
                                       config: Config.empty)
 
-    public init(outputPath: URL,
+    public init(rootPath: URL?,
+                outputPath: URL,
                 cartfilePath: URL,
                 mintfilePath: URL,
                 nestfilePath: URL,
@@ -51,6 +54,7 @@ public struct Options: Sendable {
                 csvPath: URL?,
                 licenseFileNames: [String],
                 config: Config) {
+        self.rootPath = rootPath
         self.outputPath = outputPath
         self.cartfilePath = cartfilePath
         self.mintfilePath = mintfilePath

--- a/Sources/LicensePlistCore/Extension/Optional.extension.swift
+++ b/Sources/LicensePlistCore/Extension/Optional.extension.swift
@@ -1,17 +1,24 @@
 import Foundation
 
 public extension Optional where Wrapped == String {
+    func asPathURL() -> URL? {
+        if let self = self {
+            return URL(fileURLWithPath: self, isDirectory: true, relativeTo: nil)
+        }
+        return nil
+    }
+    
     func asPathURL(in relativeURL: URL?, isDirectory: Bool = false) -> URL? {
         return map { URL(fileURLWithPath: $0, isDirectory: isDirectory, relativeTo: relativeURL) }
     }
 
-    func asPathURL(other otherURL: URL?, default defaultPath: String, isDirectory: Bool = false) -> URL {
-        return asPathURL(other: otherURL, isDirectory: isDirectory) ?? URL(fileURLWithPath: defaultPath, isDirectory: isDirectory)
+    func asPathURL(other otherURL: URL?, default defaultPath: String, isDirectory: Bool = false, relativeTo: URL?) -> URL {
+        return asPathURL(other: otherURL, isDirectory: isDirectory, relativeTo: relativeTo) ?? URL(fileURLWithPath: defaultPath, isDirectory: isDirectory, relativeTo: relativeTo)
     }
 
-    func asPathURL(other otherURL: URL?, isDirectory: Bool = false) -> URL? {
+    func asPathURL(other otherURL: URL?, isDirectory: Bool = false, relativeTo: URL?) -> URL? {
         if let path = self {
-            return URL(fileURLWithPath: path, isDirectory: isDirectory)
+            return URL(fileURLWithPath: path, isDirectory: isDirectory, relativeTo: relativeTo)
         }
         if let url = otherURL {
             return url


### PR DESCRIPTION
With XCode 26 being enforced by Apple and observing the same symptoms in #251, we reached the following observations:
- We have a license_plist.yml file where both `outputPath` and `xcworkspacePath` were relative directories.
- The plugin, and subsequently the plugin tool would run with a working directory located in DerivedData
- When the tool would run, it would open the config file (absolute path provided by the plugin), read the paths, and then resolve them against the current working directory
- The resulting locations would then not exist, and the production of the expected files would fail

Notably, if the tool invocation was copied verbatim and ran from the terminal, it would work, but only if you were in the root folder of the project.

Since the XCode plugin does not provide an option to set the working directory, this PR instead opts to pass the expected working directory to the plugin tool via a new optional CLI argument, and use that to resolve all relative paths encountered. If not set, the `nil` argument will result in path resolution against the working directory, which is the old behaviour.


note: the current state of the plugin system requires all invoked tools to be shipped as a precompiled binary. An update to Package.swift with the new URL is therefore required to use this PR successfully.