### PR TITLE
feat: Support licenseType for manual library entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ manual:
     file: "dummy_license.txt"
 ```
 
+Each entry can optionally include a `licenseType` (an SPDX identifier such as `Apache-2.0` or `MIT`), which is reflected in the generated Plist/CSV output. See [LicenseType.swift](Sources/LicensePlistCore/Entity/LicenseType.swift) for the full list of recognized identifiers.
+
 ### Excludes
 
 Excludes can be defined to exclude matching libraries from the final output.

--- a/Sources/LicensePlistCore/Entity/Manual.swift
+++ b/Sources/LicensePlistCore/Entity/Manual.swift
@@ -47,6 +47,7 @@ extension Manual {
       let name = mapping["name"]?.string ?? ""
       let version = mapping["version"]?.string
       let source = mapping["source"]?.string
+      let licenseType = LicenseType(id: mapping["licenseType"]?.string)
 
       var body: String?
       if let raw = mapping["body"]?.string {
@@ -59,7 +60,8 @@ extension Manual {
       }
 
       return Manual(
-        name: name, body: body, source: source, nameSpecified: renames[name], version: version)
+        name: name, body: body, source: source, nameSpecified: renames[name], version: version,
+        licenseType: licenseType)
     })
   }
 }

--- a/Tests/LicensePlistTests/Entity/ConfigTests.swift
+++ b/Tests/LicensePlistTests/Entity/ConfigTests.swift
@@ -20,7 +20,8 @@ class ConfigTests: XCTestCase {
                                         Manual(name: "Firebase",
                                                source: "https://github.com/firebase/firebase-ios-sdk",
                                                nameSpecified: nil,
-                                               version: "4.0.0"),
+                                               version: "4.0.0",
+                                               licenseType: .apache),
                                         Manual(name: "Dummy License File", source: nil, nameSpecified: nil, version: nil)],
                               excludes: ["RxSwift", "ios-license-generator", "/^Core.*$/"],
                               renames: ["LicensePlist": "License Plist", "WebRTC": "Web RTC"],
@@ -46,6 +47,28 @@ class ConfigTests: XCTestCase {
                                                       failIfMissingLicense: false,
                                                       addSources: false,
                                                       sandboxMode: false)))
+    }
+
+    func testManual_licenseType() {
+        let yaml = """
+            manual:
+              - name: WithType
+                licenseType: Apache-2.0
+                body: "body1"
+              - name: WithSpacedType
+                licenseType: Apache 2.0
+                body: "body2"
+              - name: UnknownType
+                licenseType: NotARealLicense
+                body: "body3"
+              - name: NoType
+                body: "body4"
+        """
+        let manuals = Config(yaml: yaml, configBasePath: URL(string: "/LicensePlist")!).manuals
+        XCTAssertEqual(manuals[0].licenseType, .apache)
+        XCTAssertEqual(manuals[1].licenseType, .apache)
+        XCTAssertEqual(manuals[2].licenseType, .unknown)
+        XCTAssertEqual(manuals[3].licenseType, .unknown)
     }
 
     func testExcludedGithubByName() {

--- a/Tests/LicensePlistTests/Resources/license_plist.yml
+++ b/Tests/LicensePlistTests/Resources/license_plist.yml
@@ -68,6 +68,7 @@ manual:
   - source: https://github.com/firebase/firebase-ios-sdk
     name: Firebase
     version: 4.0.0
+    licenseType: Apache-2.0
     body: |2
                                       Apache License
                                 Version 2.0, January 2004


### PR DESCRIPTION
fix #258

## Summary

Allow manual entries to specify licenseType directly via YAML, so users can set the license type.

```yml
manual:
  - name: SomeInternalLibrary
    source: https://example.invalid/some-lib
    version: 1.0.0
    licenseType: Apache-2.0
    body: |-
      Apache License 2.0 ...
```

