### PR TITLE
Add mise.toml support for GitHub license collection

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fb60288400d91fed9489a94ce0682963f0d0e5afd6a97bd6d8e2e2d11a3228a6",
+  "originHash" : "60f849e26dbce5153b6a73059f18d72118114c712b019d88a6c7ee089feaf220",
   "pins" : [
     {
       "identity" : "apikit",
@@ -80,6 +80,15 @@
       "state" : {
         "revision" : "f513e1dbbdd86e2ca2b672537f4bcb4417f94c27",
         "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "tomlkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/LebJe/TOMLKit.git",
+      "state" : {
+        "revision" : "ec6198d37d495efc6acd4dffbd262cdca7ff9b3f",
+        "version" : "0.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,9 @@ let package = Package(
         .package(url: "https://github.com/tomlokhorst/XcodeEdit.git",
                  from: "2.9.0"),
         .package(url: "https://github.com/jpsim/Yams.git",
-                 from: "6.0.2")
+                 from: "6.0.2"),
+        .package(url: "https://github.com/LebJe/TOMLKit.git",
+                 from: "0.6.0")
     ],
     targets: [
         .executableTarget(
@@ -44,7 +46,8 @@ let package = Package(
                 "APIKit",
                 "HeliumLogger",
                 .product(name: "HTMLEntities", package: "swift-html-entities"),
-                .product(name: "Yams", package: "Yams")
+                .product(name: "Yams", package: "Yams"),
+                .product(name: "TOMLKit", package: "TOMLKit")
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ You can see options by `license-plist --help`.
 
 - Default: `nestfile.yaml`
 
+#### `--mise-path`
+
+- Default: `mise.toml`
+- Collects GitHub-hosted tools declared in mise's `[tools]` table via the `github:`, `ubi:`, and `aqua:` backends (e.g. `"github:SwiftGen/SwiftGen" = "6.6.3"`, `[tools."ubi:BurntSushi/ripgrep"]`). Other backends and plain tool names (e.g. `node`) are ignored since they don't map to a GitHub owner/repo.
+
 #### `--pods-path`
 
 - Default: `Pods`
@@ -361,6 +366,7 @@ options:
   cartfilePath: Cartfile
   mintfilePath: Mintfile
   nestfilePath: nestfile.yaml
+  misePath: mise.toml
   podsPath: Pods
   packagePaths:
     - Package.swift

--- a/Sources/LicensePlist/main.swift
+++ b/Sources/LicensePlist/main.swift
@@ -32,6 +32,9 @@ struct LicensePlist: ParsableCommand {
     @Option(name: .long, completion: .file())
     var nestfilePath: String?
 
+    @Option(name: .long, completion: .file())
+    var misePath: String?
+
     @Option(name: .long, completion: .directory)
     var podsPath: String?
 
@@ -108,6 +111,7 @@ struct LicensePlist: ParsableCommand {
         let cartfilePath = cartfilePath.asPathURL(other: config.options.cartfilePath, default: Consts.cartfileName)
         let mintfilePath = mintfilePath.asPathURL(other: config.options.mintfilePath, default: Consts.mintfileName)
         let nestfilePath = nestfilePath.asPathURL(other: config.options.nestfilePath, default: Consts.nestfileName)
+        let misePath = misePath.asPathURL(other: config.options.misePath, default: Consts.misefileName)
         let podsPath = podsPath.asPathURL(other: config.options.podsPath, default: Consts.podsDirectoryName)
         let configPackagePaths = config.options.packagePaths ?? [URL(fileURLWithPath: Consts.packageName)]
         let packagePaths = packagePaths.isEmpty ? configPackagePaths : packagePaths.map { URL(fileURLWithPath: $0) }
@@ -126,6 +130,7 @@ struct LicensePlist: ParsableCommand {
                               cartfilePath: cartfilePath,
                               mintfilePath: mintfilePath,
                               nestfilePath: nestfilePath,
+                              misePath: misePath,
                               podsPath: podsPath,
                               packagePaths: packagePaths,
                               packageSourcesPath: packageSourcesPath,

--- a/Sources/LicensePlistCore/Consts.swift
+++ b/Sources/LicensePlistCore/Consts.swift
@@ -4,6 +4,7 @@ public struct Consts {
   public static let cartfileName = "Cartfile"
   public static let mintfileName = "Mintfile"
   public static let nestfileName = "nestfile.yaml"
+  public static let misefileName = "mise.toml"
   public static let podsDirectoryName = "Pods"
   public static let packageName = "Package.swift"
   public static let xcworkspaceExtension = "xcworkspace"

--- a/Sources/LicensePlistCore/Entity/GeneralOptions.swift
+++ b/Sources/LicensePlistCore/Entity/GeneralOptions.swift
@@ -7,6 +7,7 @@ public struct GeneralOptions: Sendable {
   public let cartfilePath: URL?
   public let mintfilePath: URL?
   public let nestfilePath: URL?
+  public let misePath: URL?
   public let podsPath: URL?
   public let packagePaths: [URL]?
   public let packageSourcesPath: URL?
@@ -31,6 +32,7 @@ public struct GeneralOptions: Sendable {
     cartfilePath: nil,
     mintfilePath: nil,
     nestfilePath: nil,
+    misePath: nil,
     podsPath: nil,
     packagePaths: nil,
     packageSourcesPath: nil,
@@ -55,6 +57,7 @@ public struct GeneralOptions: Sendable {
     cartfilePath: URL?,
     mintfilePath: URL?,
     nestfilePath: URL?,
+    misePath: URL?,
     podsPath: URL?,
     packagePaths: [URL]?,
     packageSourcesPath: URL?,
@@ -78,6 +81,7 @@ public struct GeneralOptions: Sendable {
     self.cartfilePath = cartfilePath
     self.mintfilePath = mintfilePath
     self.nestfilePath = nestfilePath
+    self.misePath = misePath
     self.podsPath = podsPath
     self.packagePaths = packagePaths
     self.packageSourcesPath = packageSourcesPath
@@ -103,6 +107,7 @@ extension GeneralOptions {
   public static func == (lhs: GeneralOptions, rhs: GeneralOptions) -> Bool {
     return lhs.outputPath == rhs.outputPath && lhs.cartfilePath == rhs.cartfilePath
       && lhs.mintfilePath == rhs.mintfilePath && lhs.nestfilePath == rhs.nestfilePath
+      && lhs.misePath == rhs.misePath
       && lhs.podsPath == rhs.podsPath && lhs.packagePaths == rhs.packagePaths
       && lhs.packageSourcesPath == rhs.packageSourcesPath && lhs.xcworkspacePath == rhs.xcworkspacePath
       && lhs.xcodeprojPath == rhs.xcodeprojPath && lhs.prefix == rhs.prefix
@@ -122,6 +127,7 @@ extension GeneralOptions {
       cartfilePath: raw["cartfilePath"]?.string.asPathURL(in: configBasePath),
       mintfilePath: raw["mintfilePath"]?.string.asPathURL(in: configBasePath),
       nestfilePath: raw["nestfilePath"]?.string.asPathURL(in: configBasePath),
+      misePath: raw["misePath"]?.string.asPathURL(in: configBasePath),
       podsPath: raw["podsPath"]?.string.asPathURL(in: configBasePath),
       packagePaths: raw["packagePaths"]?.sequence?.compactMap {
         $0.string.asPathURL(in: configBasePath)

--- a/Sources/LicensePlistCore/Entity/GitHub.swift
+++ b/Sources/LicensePlistCore/Entity/GitHub.swift
@@ -40,6 +40,9 @@ extension GitHub {
   public static func load(_ file: GitHubLibraryConfigFile, renames: [String: String] = [:])
     -> [GitHub]
   {
+    if file.type == .mise {
+      return Mise.load(content: file.content, renames: renames)
+    }
     let r = load(file, renames: renames, version: true)
     if !r.isEmpty {
       return r

--- a/Sources/LicensePlistCore/Entity/GitHubLibraryConfigFile.swift
+++ b/Sources/LicensePlistCore/Entity/GitHubLibraryConfigFile.swift
@@ -7,6 +7,7 @@ extension GitHubLibraryConfigFile {
     static func carthage(content: String?) -> GitHubLibraryConfigFile { return .init(type: .carthage, content: content) }
     static func mint(content: String?) -> GitHubLibraryConfigFile { return .init(type: .mint, content: content) }
     static func nest(content: String?) -> GitHubLibraryConfigFile { return .init(type: .nest, content: content) }
+    static func mise(content: String?) -> GitHubLibraryConfigFile { return .init(type: .mise, content: content) }
     static func licensePlist(content: String?) -> GitHubLibraryConfigFile { return .init(type: .licensePlist, content: content) }
 }
 
@@ -14,6 +15,7 @@ public enum GitHubLibraryConfigFileType: Int, CaseIterable {
     case carthage
     case mint
     case nest
+    case mise
     case licensePlist
 }
 
@@ -28,6 +30,8 @@ extension GitHubLibraryConfigFileType {
             return "(\(pattern))/(\(pattern))" + (version ? "@(\(pattern))" : "")
         case .nest:
             return "reference: (\(pattern))/(\(pattern))" + (version ? "(?:[^-]*?\\n\\s*version: (\(pattern)))" : "")
+        case .mise:
+            preconditionFailure("mise.toml is parsed by Mise.load, not the regex pipeline")
         case .licensePlist:
             return "(\(pattern))/(\(pattern))" + (version ? " (\(pattern))" : "")
         }

--- a/Sources/LicensePlistCore/Entity/Mise.swift
+++ b/Sources/LicensePlistCore/Entity/Mise.swift
@@ -1,0 +1,24 @@
+import Foundation
+import TOMLKit
+
+enum Mise {
+  private static let toolKeyRegex = try! NSRegularExpression(
+    pattern: "^(?:github|ubi|aqua):([\\w\\.\\-]+)/([\\w\\.\\-]+)$", options: [])
+
+  static func load(content: String?, renames: [String: String]) -> [GitHub] {
+    guard let content = content, let table = try? TOMLTable(string: content) else { return [] }
+    guard let tools = table["tools"]?.table else { return [] }
+
+    return tools.compactMap { key, value -> GitHub? in
+      let nsKey = key as NSString
+      guard
+        let match = toolKeyRegex.firstMatch(
+          in: key, options: [], range: NSRange(location: 0, length: nsKey.length))
+      else { return nil }
+      let owner = nsKey.substring(with: match.range(at: 1))
+      let name = nsKey.substring(with: match.range(at: 2))
+      let version = value.string ?? value.table?["version"]?.string
+      return GitHub(name: name, nameSpecified: renames[name], owner: owner, version: version)
+    }
+  }
+}

--- a/Sources/LicensePlistCore/Entity/Mise.swift
+++ b/Sources/LicensePlistCore/Entity/Mise.swift
@@ -1,24 +1,19 @@
-import Foundation
 import TOMLKit
 
 enum Mise {
-  private static let toolKeyRegex = try! NSRegularExpression(
-    pattern: "^(?:github|ubi|aqua):([\\w\\.\\-]+)/([\\w\\.\\-]+)$", options: [])
+  nonisolated(unsafe) private static let toolKeyRegex = /(?:github|ubi|aqua):([\w.-]+)\/([\w.-]+)/
 
   static func load(content: String?, renames: [String: String]) -> [GitHub] {
-    guard let content = content, let table = try? TOMLTable(string: content) else { return [] }
+    guard let content, let table = try? TOMLTable(string: content) else { return [] }
     guard let tools = table["tools"]?.table else { return [] }
 
     return tools.compactMap { key, value -> GitHub? in
-      let nsKey = key as NSString
-      guard
-        let match = toolKeyRegex.firstMatch(
-          in: key, options: [], range: NSRange(location: 0, length: nsKey.length))
-      else { return nil }
-      let owner = nsKey.substring(with: match.range(at: 1))
-      let name = nsKey.substring(with: match.range(at: 2))
+      guard let match = try? toolKeyRegex.wholeMatch(in: key) else { return nil }
+      let (_, owner, name) = match.output
       let version = value.string ?? value.table?["version"]?.string
-      return GitHub(name: name, nameSpecified: renames[name], owner: owner, version: version)
+      return GitHub(
+        name: String(name), nameSpecified: renames[String(name)], owner: String(owner),
+        version: version)
     }
   }
 }

--- a/Sources/LicensePlistCore/Entity/Options.swift
+++ b/Sources/LicensePlistCore/Entity/Options.swift
@@ -5,6 +5,7 @@ public struct Options: Sendable {
     public let cartfilePath: URL
     public let mintfilePath: URL
     public let nestfilePath: URL
+    public let misePath: URL
     public let podsPath: URL
     public let packagePaths: [URL]
     public let packageSourcesPath: URL?
@@ -22,6 +23,7 @@ public struct Options: Sendable {
                                       cartfilePath: URL(fileURLWithPath: ""),
                                       mintfilePath: URL(fileURLWithPath: ""),
                                       nestfilePath: URL(fileURLWithPath: ""),
+                                      misePath: URL(fileURLWithPath: ""),
                                       podsPath: URL(fileURLWithPath: ""),
                                       packagePaths: [],
                                       packageSourcesPath: nil,
@@ -39,6 +41,7 @@ public struct Options: Sendable {
                 cartfilePath: URL,
                 mintfilePath: URL,
                 nestfilePath: URL,
+                misePath: URL,
                 podsPath: URL,
                 packagePaths: [URL],
                 packageSourcesPath: URL?,
@@ -55,6 +58,7 @@ public struct Options: Sendable {
         self.cartfilePath = cartfilePath
         self.mintfilePath = mintfilePath
         self.nestfilePath = nestfilePath
+        self.misePath = misePath
         self.podsPath = podsPath
         self.packagePaths = packagePaths
         self.packageSourcesPath = packageSourcesPath

--- a/Sources/LicensePlistCore/Entity/PlistInfo.swift
+++ b/Sources/LicensePlistCore/Entity/PlistInfo.swift
@@ -36,6 +36,8 @@ struct PlistInfo {
             Log.info("Mint License collect start")
         case .nest:
             Log.info("nest License collect start")
+        case .mise:
+            Log.info("mise License collect start")
         case .licensePlist:
             // should not reach here
             preconditionFailure()

--- a/Sources/LicensePlistCore/LicensePlist.swift
+++ b/Sources/LicensePlistCore/LicensePlist.swift
@@ -13,6 +13,7 @@ public final class LicensePlist {
         info.loadGitHubLibraries(file: readCartfile(path: options.cartfilePath))
         info.loadGitHubLibraries(file: readMintfile(path: options.mintfilePath))
         info.loadGitHubLibraries(file: readNestfile(path: options.nestfilePath))
+        info.loadGitHubLibraries(file: readMisefile(path: options.misePath))
 
         do {
             let swiftPackageFileReadResults = try options.packagePaths.compactMap { packagePath in
@@ -87,6 +88,13 @@ private func readNestfile(path: URL) -> GitHubLibraryConfigFile {
         fatalError("Invalid nestfile name: \(path.lastPathComponent)")
     }
     return .nest(content: path.lp.read())
+}
+
+private func readMisefile(path: URL) -> GitHubLibraryConfigFile {
+    if path.lastPathComponent != Consts.misefileName {
+        fatalError("Invalid mise config file name: \(path.lastPathComponent)")
+    }
+    return .mise(content: path.lp.read())
 }
 
 private func readPodsAcknowledgements(path: URL) -> [String] {

--- a/Tests/LicensePlistTests/Entity/ConfigTests.swift
+++ b/Tests/LicensePlistTests/Entity/ConfigTests.swift
@@ -29,6 +29,7 @@ class ConfigTests: XCTestCase {
                                                       cartfilePath: URL(fileURLWithPath: "Cartfile", relativeTo: configBasePath),
                                                       mintfilePath: URL(fileURLWithPath: "Mintfile", relativeTo: configBasePath),
                                                       nestfilePath: nil,
+                                                      misePath: nil,
                                                       podsPath: URL(fileURLWithPath: "Pods", relativeTo: configBasePath),
                                                       packagePaths: [URL(fileURLWithPath: "Package.swift", relativeTo: configBasePath)],
                                                       packageSourcesPath: URL(fileURLWithPath: "./SourcePackages", isDirectory: true, relativeTo: configBasePath),

--- a/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
+++ b/Tests/LicensePlistTests/Entity/FileReader/SwiftPackageFileReaderTests.swift
@@ -15,7 +15,7 @@ class SwiftPackageFileReaderTests: XCTestCase {
     var packageResolvedText: String {
         return #"""
         {
-          "originHash" : "fb60288400d91fed9489a94ce0682963f0d0e5afd6a97bd6d8e2e2d11a3228a6",
+          "originHash" : "60f849e26dbce5153b6a73059f18d72118114c712b019d88a6c7ee089feaf220",
           "pins" : [
             {
               "identity" : "apikit",
@@ -96,6 +96,15 @@ class SwiftPackageFileReaderTests: XCTestCase {
               "state" : {
                 "revision" : "f513e1dbbdd86e2ca2b672537f4bcb4417f94c27",
                 "version" : "2.2.1"
+              }
+            },
+            {
+              "identity" : "tomlkit",
+              "kind" : "remoteSourceControl",
+              "location" : "https://github.com/LebJe/TOMLKit.git",
+              "state" : {
+                "revision" : "ec6198d37d495efc6acd4dffbd262cdca7ff9b3f",
+                "version" : "0.6.0"
               }
             },
             {

--- a/Tests/LicensePlistTests/Entity/GitHubLibraryConfigFileTests.swift
+++ b/Tests/LicensePlistTests/Entity/GitHubLibraryConfigFileTests.swift
@@ -7,6 +7,7 @@ class GitHubLibraryConfigFileTests: XCTestCase {
         XCTAssertEqual(GitHubLibraryConfigFile.carthage(content: "content"), GitHubLibraryConfigFile(type: .carthage, content: "content"))
         XCTAssertEqual(GitHubLibraryConfigFile.mint(content: "content"), GitHubLibraryConfigFile(type: .mint, content: "content"))
         XCTAssertEqual(GitHubLibraryConfigFile.nest(content: "content"), GitHubLibraryConfigFile(type: .nest, content: "content"))
+        XCTAssertEqual(GitHubLibraryConfigFile.mise(content: "content"), GitHubLibraryConfigFile(type: .mise, content: "content"))
         XCTAssertEqual(GitHubLibraryConfigFile.licensePlist(content: "content"), GitHubLibraryConfigFile(type: .licensePlist, content: "content"))
     }
 }

--- a/Tests/LicensePlistTests/Entity/GitHubTests.swift
+++ b/Tests/LicensePlistTests/Entity/GitHubTests.swift
@@ -117,4 +117,77 @@ class GitHubTests: XCTestCase {
         let result2 = results[1]
         XCTAssertEqual(result2, GitHub(name: "NativePopup", nameSpecified: nil, owner: "mono0926", version: nil))
     }
+
+    func testParse_mise_string() {
+        let results = GitHub.load(
+            .mise(
+                content: """
+                [tools]
+                "ubi:BurntSushi/ripgrep" = "14.1.0"
+                """
+            )
+        )
+        XCTAssertTrue(results.count == 1)
+        let result = results.first
+        XCTAssertEqual(result, GitHub(name: "ripgrep", nameSpecified: nil, owner: "BurntSushi", version: "14.1.0"))
+    }
+
+    func testParse_mise_inlineTable() {
+        let results = GitHub.load(
+            .mise(
+                content: """
+                [tools]
+                "github:SwiftGen/SwiftGen" = { version = "6.6.3", os = ["macos"] }
+                """
+            )
+        )
+        XCTAssertTrue(results.count == 1)
+        let result = results.first
+        XCTAssertEqual(result, GitHub(name: "SwiftGen", nameSpecified: nil, owner: "SwiftGen", version: "6.6.3"))
+    }
+
+    func testParse_mise_tableHeader() {
+        let results = GitHub.load(
+            .mise(
+                content: """
+                [tools."aqua:cli/cli"]
+                version = "2.40.0"
+                """
+            )
+        )
+        XCTAssertTrue(results.count == 1)
+        let result = results.first
+        XCTAssertEqual(result, GitHub(name: "cli", nameSpecified: nil, owner: "cli", version: "2.40.0"))
+    }
+
+    func testParse_mise_skipsUnsupportedBackend() {
+        let results = GitHub.load(
+            .mise(
+                content: """
+                [tools]
+                node = "20.11.0"
+                "npm:eslint" = "9.0.0"
+                "github:realm/SwiftLint" = "0.55.1"
+                """
+            )
+        )
+        XCTAssertTrue(results.count == 1)
+        let result = results.first
+        XCTAssertEqual(result, GitHub(name: "SwiftLint", nameSpecified: nil, owner: "realm", version: "0.55.1"))
+    }
+
+    func testParse_mise_rename() {
+        let results = GitHub.load(
+            .mise(
+                content: """
+                [tools]
+                "ubi:BurntSushi/ripgrep" = "14.1.0"
+                """
+            ),
+            renames: ["ripgrep": "ripgrep2"]
+        )
+        XCTAssertTrue(results.count == 1)
+        let result = results.first
+        XCTAssertEqual(result, GitHub(name: "ripgrep", nameSpecified: "ripgrep2", owner: "BurntSushi", version: "14.1.0"))
+    }
 }

--- a/Tests/LicensePlistTests/Entity/LicensePlistHolderTests.swift
+++ b/Tests/LicensePlistTests/Entity/LicensePlistHolderTests.swift
@@ -113,6 +113,7 @@ extension Options {
             cartfilePath: .init(fileURLWithPath: ""),
             mintfilePath: .init(fileURLWithPath: ""),
             nestfilePath: .init(fileURLWithPath: ""),
+            misePath: .init(fileURLWithPath: ""),
             podsPath: .init(fileURLWithPath: ""),
             packagePaths: [],
             packageSourcesPath: nil,

--- a/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
+++ b/Tests/LicensePlistTests/Entity/PlistInfoTests.swift
@@ -15,6 +15,7 @@ class PlistInfoTests: XCTestCase {
     cartfilePath: URL(fileURLWithPath: "test_result_dir"),
     mintfilePath: URL(fileURLWithPath: "test_result_dir"),
     nestfilePath: URL(fileURLWithPath: "test_result_dir"),
+    misePath: URL(fileURLWithPath: "test_result_dir"),
     podsPath: URL(fileURLWithPath: "test_result_dir"),
     packagePaths: [URL(fileURLWithPath: "test_result_dir")],
     packageSourcesPath: nil,

--- a/Tests/LicensePlistTests/Entity/PlistInfoWithSourcePackagesTests.swift
+++ b/Tests/LicensePlistTests/Entity/PlistInfoWithSourcePackagesTests.swift
@@ -60,6 +60,7 @@ final class PlistInfoWithSourcePackagesTests: XCTestCase {
                        cartfilePath: URL(fileURLWithPath: "test_result_dir"),
                        mintfilePath: URL(fileURLWithPath: "test_result_dir"),
                        nestfilePath: URL(fileURLWithPath: "test_result_dir"),
+                       misePath: URL(fileURLWithPath: "test_result_dir"),
                        podsPath: URL(fileURLWithPath: "test_result_dir"),
                        packagePaths: [URL(fileURLWithPath: "test_result_dir")],
                        packageSourcesPath: sourcePackagesPath,


### PR DESCRIPTION
## Summary
- Add support for collecting GitHub license info from `mise.toml`'s `[tools]` table, similar to existing Mintfile/Cartfile/nestfile support.
- Supports entries using the `github:`, `ubi:`, and `aqua:` mise backends (which reference a GitHub `owner/repo`), in all three syntaxes mise allows:
  - `"github:owner/repo" = "1.2.3"`
  - `"ubi:owner/repo" = { version = "1.2.3", os = ["macos"] }`
  - `[tools."aqua:owner/repo"]` + `version = "1.2.3"`
- Other backends and plain tool names (e.g. `node = "20.11.0"`) are ignored since they don't map to a GitHub owner/repo.
- Since `mise.toml` is real TOML with nested/inline tables (unlike the simple regex-parsable Mintfile/Cartfile/nestfile formats), this adds the `TOMLKit` dependency and a dedicated parser (`Sources/LicensePlistCore/Entity/Mise.swift`) rather than reusing the existing regex pipeline.
- Adds a `--mise-path` CLI option (default `mise.toml`) and YAML config equivalent, mirroring `--mintfile-path`.

## Test plan
- [x] `swift build` succeeds with the new `TOMLKit` dependency
- [x] `swift test` passes (125 tests, including new unit tests for `Mise.load` covering all three supported syntaxes and unsupported-backend skipping)
- [x] Manually ran the built `license-plist` binary against a sample `mise.toml` and confirmed the 3 GitHub-backed entries were collected (with licenses downloaded) while a plain `node` entry was correctly skipped
- [ ] README `--mise-path` docs reviewed